### PR TITLE
Location bugfix

### DIFF
--- a/src/Event.C
+++ b/src/Event.C
@@ -8,24 +8,24 @@
 #include "Event.h"
 
 // This is just so that we can order Events in the Location queues
-bool Event::operator>(const Event& rhs) const {
+bool Event::operator<(const Event& rhs) const {
   // First compare times...
   if (scheduledTime != rhs.scheduledTime) {
-    return scheduledTime > rhs.scheduledTime;
+    return scheduledTime < rhs.scheduledTime;
   }
 
   // .. then break ties with the type...
   if (type != rhs.type) {
-    return type > rhs.type;
+    return type < rhs.type;
   }
 
   // ...then break ties with the visitor's index...
   if (personIdx != rhs.personIdx) {
-    return personIdx > rhs.personIdx;
+    return personIdx < rhs.personIdx;
   }
 
   // ...then finally break ties with the visitor's state
-  return personState > rhs.personState;
+  return personState < rhs.personState;
 }
 
 // Compares two events based on the correspodning other event (if one is an

--- a/src/Event.h
+++ b/src/Event.h
@@ -27,7 +27,7 @@ struct Event {
   int partnerTime;
 
   // Lets us order events in the location queues
-  bool operator>(const Event& rhs) const;
+  bool operator<(const Event& rhs) const;
 
   // Compares events based on their partners, returning whether or not e0's
   // partner is greater than e1's. Assumes both partnes are non-null

--- a/src/Location.C
+++ b/src/Location.C
@@ -34,7 +34,7 @@ std::vector<union Data> &Location::getDataField() {
 
 // Event processing.
 void Location::addEvent(Event e) {
-  events.push(e);
+  events.push_back(e);
 }
 
 void Location::processEvents(
@@ -42,16 +42,13 @@ void Location::processEvents(
   ContactModel *contactModel
 ) {
   std::vector<Event> *arrivals;
-  Event curEvent;
-
-  while (!events.empty()) {
-    curEvent = events.top();
-    events.pop();
-
-    if (diseaseModel->isSusceptible(curEvent.personState)) {
+  
+  std::sort(events.begin(), events.end());
+  for (Event event: events) {
+    if (diseaseModel->isSusceptible(event.personState)) {
       arrivals = &susceptibleArrivals;
 
-    } else if (diseaseModel->isInfectious(curEvent.personState)) {
+    } else if (diseaseModel->isInfectious(event.personState)) {
       arrivals = &infectiousArrivals;
 
     // If a person can niether infect other people nor be infected themself,
@@ -60,19 +57,20 @@ void Location::processEvents(
       continue;
     }
 
-    if (ARRIVAL == curEvent.type) {
-      arrivals->push_back(curEvent);
+    if (ARRIVAL == event.type) {
+      arrivals->push_back(event);
       std::push_heap(arrivals->begin(), arrivals->end(), Event::greaterPartner);
 
-    } else if (DEPARTURE == curEvent.type) {
+    } else if (DEPARTURE == event.type) {
       // Remove the arrival event corresponding to this departure 
       std::pop_heap(arrivals->begin(), arrivals->end(), Event::greaterPartner);
       arrivals->pop_back();
 
-      onDeparture(diseaseModel, contactModel, curEvent);
+      onDeparture(diseaseModel, contactModel, event);
     }
   }
 
+  events.clear();
   interactions.clear();
 }
 

--- a/src/Location.h
+++ b/src/Location.h
@@ -16,7 +16,6 @@ class Location;
 #include "contact_model/ContactModel.h"
 #include "readers/DataInterface.h"
 
-#include <queue>
 #include <vector>
 #include <functional>
 #include <random>
@@ -30,7 +29,7 @@ class Location : public DataInterface {
   private:
     // Represents all of the arrivals and departures of people
     // from this location on a given day
-    std::priority_queue<Event, std::vector<Event>, std::greater<Event> > events;
+    std::vector<Event> events;
     // Each Event in one of these containers is the arrival event for a
     // a person currently at this location
     std::vector<Event> infectiousArrivals;

--- a/src/Locations.C
+++ b/src/Locations.C
@@ -35,11 +35,10 @@ Locations::Locations() {
 
   // Load application data
   if (syntheticRun) {
-    Location tmp { 0 };
+    Location tmp(0);
     locations.resize(numLocalLocations, tmp);
+
   } else {
-    Location tmp { 0 };
-    locations.resize(numLocalLocations, tmp);
     loadLocationData();
   }
 


### PR DESCRIPTION
Fixes issues with `Locations.C` and `Location.C` that were causing memory errors/segfaults.

Specifically, it contains tow major changes:
1. We just add `Event`s to a vector now and sort them before processing them, rather than using a priority queue. (Not sure if this helped with any errors or not, but I thought it was a bit cleaner, so I left it in.)
2. We no longer create an extra slate of `Location`s in `Locations` during non-synthetic runs (previously, we were creating `numLocalLocations` `Location`s with no attributes and then adding the same number number of `Location`s with attribute data from the input files.