### PR TITLE
Introduces grid based synthetic visits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,11 @@ jobs:
         export CHARM_HOME=$GITHUB_WORKSPACE/charm-nonsmp
         export PATH=$CHARM_HOME/bin:$PATH_PROTOBUF
         make
-        ./charmrun +p4 ./loimos 39 16 1 4 7 ../data/disease_models/covid19.textproto +setcpuaffinity ++local
+        ./charmrun +p4 ./loimos 1 10 10 5 5 3 32 16 30 ../data/disease_models/covid19.textproto +setcpuaffinity ++local
         make clean
         # Test SMP
         export CHARM_HOME=$GITHUB_WORKSPACE/charm-smp
         export PATH=$CHARM_HOME/bin:$PATH_PROTOBUF
         make
-        ./charmrun +p4 ./loimos 39 16 1 4 7 ../data/disease_models/covid19.textproto +ppn 2 +setcpuaffinity ++local
+        ./charmrun +p4 ./loimos 1 10 10 5 5 3 32 16 30 ../data/disease_models/covid19.textproto +setcpuaffinity ++local
         make clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,11 @@ jobs:
         export CHARM_HOME=$GITHUB_WORKSPACE/charm-nonsmp
         export PATH=$CHARM_HOME/bin:$PATH_PROTOBUF
         make
-        ./charmrun +p4 ./loimos 1 10 10 5 5 3 32 16 30 ../data/disease_models/covid19.textproto +setcpuaffinity ++local
+        ./charmrun +p4 ./loimos 1 100 100 50 50 5 5 5 32 30 ../data/disease_models/covid19_onepath.textproto +setcpuaffinity ++local
         make clean
         # Test SMP
         export CHARM_HOME=$GITHUB_WORKSPACE/charm-smp
         export PATH=$CHARM_HOME/bin:$PATH_PROTOBUF
         make
-        ./charmrun +p4 ./loimos 1 10 10 5 5 3 32 16 30 ../data/disease_models/covid19.textproto +setcpuaffinity ++local
+        ./charmrun +p4 ./loimos 1 100 100 50 50 5 5 5 32 30 ../data/disease_models/covid19_onepath.textproto +setcpuaffinity ++local
         make clean

--- a/src/Defs.C
+++ b/src/Defs.C
@@ -40,21 +40,6 @@ int getNumLocalElements(int numElements, int numPartitions, int partitionIndex){
 }
 
 /**
- * Returns how many elements wide a 2D parition is
- *
- * Args:
- *    int numElements: The total number of elements in the 2D parition
- */
-int getGridWidth(int numElements) {
-  int width;
-  // Try to get a value which evenly divides numElements while still being
-  // fairly close to the other factor
-  for (width = floor(sqrt(numElements)); numElements % width != 0; ++width);
-
-  return width;
-}
-
-/**
  * Returns the number of the chare that tracks a particular element. 
  * 
  * Args:

--- a/src/Defs.C
+++ b/src/Defs.C
@@ -40,6 +40,21 @@ int getNumLocalElements(int numElements, int numPartitions, int partitionIndex){
 }
 
 /**
+ * Returns how many elements wide a 2D parition is
+ *
+ * Args:
+ *    int numElements: The total number of elements in the 2D parition
+ */
+int getGridWidth(int numElements) {
+  int width;
+  // Try to get a value which evenly divides numElements while still being
+  // fairly close to the other factor
+  for (width = floor(sqrt(numElements)); numElements % width != 0; ++width);
+
+  return width;
+}
+
+/**
  * Returns the number of the chare that tracks a particular element. 
  * 
  * Args:

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -64,6 +64,10 @@ extern /* readonly */ int synPeopleGridWidth;
 extern /* readonly */ int synPeopleGridHeight;
 extern /* readonly */ int synLocationGridWidth;
 extern /* readonly */ int synLocationGridHeight;
+extern /* readonly */ int synLocalLocationGridWidth;
+extern /* readonly */ int synLocalLocationGridHeight;
+extern /* readonly */ int synLocationPartitionGridWidth;
+extern /* readonly */ int synLocationPartitionGridHeight;
 extern /* readonly */ int averageDegreeOfVisit;
 
 int getNumElementsPerPartition(int numElements, int numPartitions);

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -48,11 +48,20 @@ extern /* readonly */ int numPeoplePartitions;
 extern /* readonly */ int numLocationPartitions;
 extern /* readonly */ int numDays;
 extern /* readonly */ bool syntheticRun;
-extern /* readonly */ int firstPersonIdx;
-extern /* readonly */ int firstLocationIdx;
+extern /* readonly */ double simulationStartTime;
+
+// For real data run.
 extern /* readonly */ std::string scenarioPath;
 extern /* readonly */ std::string scenarioId;
-extern /* readonly */ double simulationStartTime;
+extern /* readonly */ int firstPersonIdx;
+extern /* readonly */ int firstLocationIdx;
+
+// For synthetic run.
+extern /* readonly */ int synPeopleGridWidth;
+extern /* readonly */ int synPeopleGridHeight;
+extern /* readonly */ int synLocationGridWidth;
+extern /* readonly */ int synLocationGridHeight;
+extern /* readonly */ int averageDegreeOfVisit;
 
 int getNumElementsPerPartition(int numElements, int numPartitions);
 

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -67,6 +67,8 @@ int getNumElementsPerPartition(int numElements, int numPartitions);
 
 int getNumLocalElements(int numElements, int numPartitions, int partitionIndex);
 
+int getGridWidth(int numElements);
+
 int getPartitionIndex(int globalIndex, int numElements, int numPartitions, int offset);
 
 int getLocalIndex(int globalIndex, int numElements, int numPartitions, int offset);

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -74,8 +74,6 @@ int getNumElementsPerPartition(int numElements, int numPartitions);
 
 int getNumLocalElements(int numElements, int numPartitions, int partitionIndex);
 
-int getGridWidth(int numElements);
-
 int getPartitionIndex(int globalIndex, int numElements, int numPartitions, int offset);
 
 int getLocalIndex(int globalIndex, int numElements, int numPartitions, int offset);

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -48,7 +48,10 @@ extern /* readonly */ int numPeoplePartitions;
 extern /* readonly */ int numLocationPartitions;
 extern /* readonly */ int numDays;
 extern /* readonly */ bool syntheticRun;
+extern /* readonly */ uint64_t totalVisits;
 extern /* readonly */ double simulationStartTime;
+extern /* readonly */ double iterationStartTime;
+
 
 // For real data run.
 extern /* readonly */ std::string scenarioPath;

--- a/src/DiseaseModel.C
+++ b/src/DiseaseModel.C
@@ -37,6 +37,9 @@ DiseaseModel::DiseaseModel(std::string pathToModel) {
   // TODO(iancostello): Load directly without string.
   model = new loimos::proto::DiseaseModel();
   std::ifstream diseaseModelStream(pathToModel);
+  if (!diseaseModelStream) {
+    CkAbort("Could not read disease model at %s.", pathToModel.c_str());
+  }
   std::string str((std::istreambuf_iterator<char>(diseaseModelStream)),
                   std::istreambuf_iterator<char>());
   if (!google::protobuf::TextFormat::ParseFromString(str, model)) {
@@ -98,9 +101,6 @@ std::tuple<int, int> DiseaseModel::transitionFromState(
   std::default_random_engine *generator
 ) const {
   // Get current state and next transition set to use.
-  if (fromState >= model->disease_state_size()) {
-    printf("Expecting %d but got %d", fromState, model->disease_state_size());
-  }
   const loimos::proto::DiseaseModel_DiseaseState *currState =
       &model->disease_state(fromState);
 
@@ -209,7 +209,7 @@ int DiseaseModel::getHealthyState(std::vector<Data> dataField) const {
       return state.starting_state();
     }
   }
-  CkAbort("No starting state for person of age %d.", personAge);  
+  CkAbort("No starting state for person of age %d. Read %d states total.", personAge, numStartingStates);  
 }
 
 /** Returns if someone is infectious */

--- a/src/Locations.C
+++ b/src/Locations.C
@@ -113,6 +113,9 @@ void Locations::ReceiveVisitMessages(VisitMessage visitMsg) {
     firstLocationIdx
   );
 
+  CkPrintf("Visiting location %d (%d of %d locally)\r\n",
+    visitMsg.locationIdx, localLocIdx, numLocalLocations);
+
   // Wrap vist info...
   Event arrival { ARRIVAL, visitMsg.personIdx, visitMsg.personState, visitMsg.visitStart };
   Event departure { DEPARTURE, visitMsg.personIdx, visitMsg.personState, visitMsg.visitEnd };

--- a/src/Locations.C
+++ b/src/Locations.C
@@ -113,8 +113,8 @@ void Locations::ReceiveVisitMessages(VisitMessage visitMsg) {
     firstLocationIdx
   );
 
-  CkPrintf("Visiting location %d (%d of %d locally)\r\n",
-    visitMsg.locationIdx, localLocIdx, numLocalLocations);
+  //CkPrintf("Visiting location %d (%d of %d locally)\r\n",
+  //  visitMsg.locationIdx, localLocIdx, numLocalLocations);
 
   // Wrap vist info...
   Event arrival { ARRIVAL, visitMsg.personIdx, visitMsg.personState, visitMsg.visitStart };

--- a/src/Locations.C
+++ b/src/Locations.C
@@ -104,6 +104,7 @@ void Locations::loadLocationData() {
 }
 
 void Locations::ReceiveVisitMessages(VisitMessage visitMsg) {
+  
   // adding person to location visit list
   int localLocIdx = getLocalIndex(
     visitMsg.locationIdx,

--- a/src/Main.C
+++ b/src/Main.C
@@ -135,14 +135,17 @@ Main::Main(CkArgMsg* msg) {
 
 
   // Instantiate DiseaseModel nodegroup (One for each physical processor).
-  CkPrintf("Loading diseaseModel.\n");
+  CkPrintf("Loading diseaseModel at %s.\n", pathToDiseaseModel.c_str());
   globDiseaseModel = CProxy_DiseaseModel::ckNew(pathToDiseaseModel);
   diseaseModel = globDiseaseModel.ckLocalBranch();
   accumulated.resize(diseaseModel->getNumberOfStates(), 0);
   delete msg;
 
   // creating chare arrays
-  CkPrintf("Loading people and locations.\n");
+  if (!syntheticRun) {
+    CkPrintf("Loading people and locations from %s.\n", scenarioPath.c_str());
+  }
+  
   peopleArray = CProxy_People::ckNew(numPeoplePartitions);
   locationsArray = CProxy_Locations::ckNew(numLocationPartitions);
 

--- a/src/Main.C
+++ b/src/Main.C
@@ -98,8 +98,8 @@ Main::Main(CkArgMsg* msg) {
   } else {
     numPeople = atoi(msg->argv[2]);
     numLocations = atoi(msg->argv[3]);
-    numLocationPartitions = atoi(msg->argv[4]);
-    numPeoplePartitions = atoi(msg->argv[5]);
+    numPeoplePartitions = atoi(msg->argv[4]);
+    numLocationPartitions = atoi(msg->argv[5]);
     baseRunInfo = 5;
   }
   

--- a/src/Main.C
+++ b/src/Main.C
@@ -31,36 +31,63 @@
 /* readonly */ int firstLocationIdx;
 /* readonly */ double simulationStartTime;
 
+// For synthetic run.
+/* readonly */ int synPeopleGridWidth;
+/* readonly */ int synPeopleGridHeight;
+/* readonly */ int synLocationGridWidth;
+/* readonly */ int synLocationGridHeight;
+/* readonly */ int averageDegreeOfVisit;
+
+
 Main::Main(CkArgMsg* msg) {
   // parsing command line arguments
   if(msg->argc < 7){
     CkPrintf("Error, usage %s <people> <locations> <people subsets> <location subsets> <days> <disease_model_path> <scenario_folder (optional)>\n", msg->argv[0]);
     CkExit();
   }
-  numPeople = atoi(msg->argv[1]);
-  numLocations = atoi(msg->argv[2]);
-  numPeoplePartitions = atoi(msg->argv[3]);
-  numLocationPartitions = atoi(msg->argv[4]);
-  numDays = atoi(msg->argv[5]);
-  std::string pathToDiseaseModel = std::string(msg->argv[6]);
+  syntheticRun = atoi(msg->argv[1]) == 1;
+  int baseRunInfo = 0;
+  if (syntheticRun) {
+    // Get number of people.
+    synPeopleGridWidth = atoi(msg->argv[2]);
+    synPeopleGridHeight = atoi(msg->argv[3]);
+    numPeople = synPeopleGridWidth * synPeopleGridHeight;
+    // Location data
+    synLocationGridWidth = atoi(msg->argv[4]);
+    synLocationGridHeight = atoi(msg->argv[5]);
+    numLocations = synLocationGridWidth * synLocationGridHeight;
+    assert(synPeopleGridWidth >= synLocationGridWidth);
+    assert(synPeopleGridHeight >= synLocationGridHeight);
+
+    // Edge degree.
+    averageDegreeOfVisit = atoi(msg->argv[6]);
+    baseRunInfo = 6;
+  } else {
+    numPeople = atoi(msg->argv[2]);
+    numLocations = atoi(msg->argv[3]);
+    baseRunInfo = 3;
+  }
+  
+  numPeoplePartitions = atoi(msg->argv[baseRunInfo + 1]);
+  numLocationPartitions = atoi(msg->argv[baseRunInfo + 2]);
+  numDays = atoi(msg->argv[baseRunInfo + 3]);
+  std::string pathToDiseaseModel = std::string(msg->argv[baseRunInfo + 4]);
 
   // Handle both real data runs or runs using synthetic populations.
-  if(msg->argc >= 8) {
-    syntheticRun = false;
-    
-    // Create data caches.
-    scenarioPath = std::string(msg->argv[7]);
-    std::tie(firstPersonIdx, firstLocationIdx, scenarioId) = buildCache(scenarioPath, numPeople, numPeoplePartitions, numLocations, numLocationPartitions, numDays);
-  } else {
-    syntheticRun = true;
+  if(syntheticRun) {
+    CkPrintf("Synthetic run with (%d, %d) person grid and (%d, %d) location grid. Average degree of %d\n", synPeopleGridWidth, synPeopleGridHeight, synLocationGridWidth, synLocationGridHeight, averageDegreeOfVisit);
     firstPersonIdx = 0;
     firstLocationIdx = 0;
+  } else {    
+    // Create data caches.
+    scenarioPath = std::string(msg->argv[baseRunInfo + 5]);
+    std::tie(firstPersonIdx, firstLocationIdx, scenarioId) = buildCache(scenarioPath, numPeople, numPeoplePartitions, numLocations, numLocationPartitions, numDays);
   }
 
   // Detemine which contact modle to use
   contactModelType = (int) ContactModelType::constant_probability;
-  if (msg->argc >= 9) {
-    std::string tmp = std::string(msg->argv[8]);
+  if (msg->argc == baseRunInfo + 7) {
+    std::string tmp = std::string(msg->argv[baseRunInfo + 6]);
     // We can just use a flag for now in the CLI, since we only have two
     // models and that's easier to parse, but we may eventually have more,
     // which is why we use an enum to actually hold the model value

--- a/src/Main.C
+++ b/src/Main.C
@@ -29,7 +29,9 @@
 /* readonly */ std::string scenarioId;
 /* readonly */ int firstPersonIdx;
 /* readonly */ int firstLocationIdx;
+/* readonly */ uint64_t totalVisits;
 /* readonly */ double simulationStartTime;
+/* readonly */ double iterationStartTime;
 
 // For synthetic run.
 /* readonly */ int synPeopleGridWidth;

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,13 +60,13 @@ TESTS=$(subst -,test-,$(TEST_NAMES))
 test: $(TESTS)
 
 test-small: all
-	./charmrun +p4 ./loimos 100 735 2 2 7 ../data/disease_models/covid19.textproto ../data/populations/synthetic_small_city/ ++local
+	./charmrun +p4 ./loimos 0 100 735 2 2 7 ../data/disease_models/covid19.textproto ../data/populations/synthetic_small_city/ ++local
 
 test-syn: all
-	./charmrun +p4 ./loimos 4000 500 16 16 7 ../data/disease_models/covid19.textproto ++local
+	./charmrun +p4 ./loimos 1 200 200 100 100 5 32 16 30 ../data/disease_models/covid19_onepath.textproto ++local
 
 test-large: all
-	./charmrun +p4 ./loimos 41119 19203 60 40 7 ../data/disease_models/covid19.textproto ../data/populations/coc/ --min-max-alpha ++local
+	./charmrun +p4 ./loimos 0 41119 19203 60 40 7 ../data/disease_models/covid19.textproto ../data/populations/coc/ --min-max-alpha ++local
 
 clean-cache:
 	rm ../data/populations/coc/*.cache ../data/populations/synthetic_small_city/*.cache

--- a/src/Makefile
+++ b/src/Makefile
@@ -63,7 +63,7 @@ test-small: all
 	./charmrun +p4 ./loimos 0 100 735 2 2 7 ../data/disease_models/covid19.textproto ../data/populations/synthetic_small_city/ ++local
 
 test-syn: all
-	./charmrun +p4 ./loimos 1 200 200 100 100 5 32 16 30 ../data/disease_models/covid19_onepath.textproto ++local
+	./charmrun +p4 ./loimos 1 100 100 50 50 5 32 16 30 ../data/disease_models/covid19_onepath.textproto ++local
 
 test-large: all
 	./charmrun +p4 ./loimos 0 41119 19203 60 40 7 ../data/disease_models/covid19.textproto ../data/populations/coc/ --min-max-alpha ++local

--- a/src/Makefile
+++ b/src/Makefile
@@ -63,7 +63,7 @@ test-small: all
 	./charmrun +p4 ./loimos 0 100 735 2 2 7 ../data/disease_models/covid19.textproto ../data/populations/synthetic_small_city/ ++local
 
 test-syn: all
-	./charmrun +p4 ./loimos 1 100 100 50 50 5 32 16 30 ../data/disease_models/covid19_onepath.textproto ++local
+	./charmrun +p4 ./loimos 1 100 100 50 50 5 5 5 32 30 ../data/disease_models/covid19_onepath.textproto ++local
 
 test-large: all
 	./charmrun +p4 ./loimos 0 41119 19203 60 40 7 ../data/disease_models/covid19.textproto ../data/populations/coc/ --min-max-alpha ++local

--- a/src/People.C
+++ b/src/People.C
@@ -162,12 +162,11 @@ void People::SyntheticSendVisitMessages() {
     numLocations,
     numLocationPartitions
   );
-  int locationPartitionWidth = getGridWidth(numLocationsPerPartition);
-  int locationPartitionHeight =
-    numLocationsPerPartition / locationPartitionWidth;
-  int locationPartitionGridWidth = getGridWidth(numLocationPartitions);
-  CkPrintf("location grid at each chare is %d by %d\r\n",
-    locationPartitionWidth, locationPartitionHeight);
+  int locationPartitionWidth = synLocalLocationGridWidth;
+  int locationPartitionHeight = synLocalLocationGridHeight;
+  int locationPartitionGridWidth = synLocationPartitionGridWidth;
+  //CkPrintf("location grid at each chare is %d by %d\r\n",
+  //  locationPartitionWidth, locationPartitionHeight);
 
   // Choose one location partition for the people in this parition to call home
   int homePartitionIdx = thisIndex % numLocationPartitions;
@@ -264,11 +263,11 @@ void People::SyntheticSendVisitMessages() {
         + (destinationY % locationPartitionHeight) * locationPartitionWidth
         + partitionX * numLocationsPerPartition
         + partitionY * locationPartitionGridWidth * numLocationsPerPartition;
-      CkPrintf(
-        "person %d will visit location (%d, %d) with offset (%d,%d)\r\n",
-        personIdx, destinationX, destinationY, destinationOffsetX, destinationOffsetY);
-        CkPrintf("(%d, %d) -> %d in partition (%d, %d)\r\n",
-          destinationX, destinationY, destinationIdx, partitionX, partitionY);
+      //CkPrintf(
+      //  "person %d will visit location (%d, %d) with offset (%d,%d)\r\n",
+      //  personIdx, destinationX, destinationY, destinationOffsetX, destinationOffsetY);
+      //  CkPrintf("(%d, %d) -> %d in partition (%d, %d)\r\n",
+      //    destinationX, destinationY, destinationIdx, partitionX, partitionY);
 
       // Determine which chare tracks this location.
       int locationPartition = getPartitionIndex(

--- a/src/People.C
+++ b/src/People.C
@@ -248,6 +248,7 @@ void People::SyntheticSendVisitMessages() {
             destinationOffsetY = -std::min(numHops, maxHopsNegativeY);
           }
         }
+        // CkPrintf("Home is (%d, %d) (%d %d %d %d))\n", homeX, homeY, maxHopsNegativeX, maxHopsPositiveX, maxHopsNegativeY, maxHopsPositiveY);
       }
 
       // Finally calculate the index of the location to actually visit...

--- a/src/People.C
+++ b/src/People.C
@@ -166,6 +166,8 @@ void People::SyntheticSendVisitMessages() {
   int locationPartitionHeight =
     numLocationsPerPartition / locationPartitionWidth;
   int locationPartitionGridWidth = getGridWidth(numLocationPartitions);
+  CkPrintf("location grid at each chare is %d by %d\r\n",
+    locationPartitionWidth, locationPartitionHeight);
 
   // Choose one location partition for the people in this parition to call home
   int homePartitionIdx = thisIndex % numLocationPartitions;
@@ -262,6 +264,11 @@ void People::SyntheticSendVisitMessages() {
         + (destinationY % locationPartitionHeight) * locationPartitionWidth
         + partitionX * numLocationsPerPartition
         + partitionY * locationPartitionGridWidth * numLocationsPerPartition;
+      CkPrintf(
+        "person %d will visit location (%d, %d) with offset (%d,%d)\r\n",
+        personIdx, destinationX, destinationY, destinationOffsetX, destinationOffsetY);
+        CkPrintf("(%d, %d) -> %d in partition (%d, %d)\r\n",
+          destinationX, destinationY, destinationIdx, partitionX, partitionY);
 
       // Determine which chare tracks this location.
       int locationPartition = getPartitionIndex(

--- a/src/People.C
+++ b/src/People.C
@@ -157,8 +157,6 @@ void People::SyntheticSendVisitMessages() {
   std::priority_queue<int, std::vector<int>, std::greater<int> > times;
 
   // Calculate minigrid sizes.
-  int peoplePerLocationX = synPeopleGridWidth / synLocationGridWidth;
-  int peoplePerLocationY = synPeopleGridHeight / synLocationGridHeight;
   int numLocationsPerPartition = getNumElementsPerPartition(
     numLocations,
     numLocationPartitions
@@ -167,9 +165,6 @@ void People::SyntheticSendVisitMessages() {
   int locationPartitionHeight =
     numLocationsPerPartition / locationPartitionWidth;
   int locationPartitionGridWidth = getGridWidth(numLocationPartitions);
-
-  //CkPrintf("location partitions are %d by %d\r\n",
-  //  locationPartitionWidth, locationPartitionHeight);
 
   // Choose one location partition for the people in this parition to call home
   int homePartitionIdx = thisIndex % numLocationPartitions;
@@ -182,8 +177,6 @@ void People::SyntheticSendVisitMessages() {
     numLocationPartitions,
     homePartitionIdx
   );
-  //CkPrintf("home location partition (%d, %d) starts at (%d, %d)\r\n",
-  //  homePartitionX, homePartitionY, homePartitionStartX, homePartitionStartY);
 
   // Calculate schedule for each person.
   for (Person &p : people) {
@@ -192,12 +185,6 @@ void People::SyntheticSendVisitMessages() {
     int localPersonIdx = (personIdx - firstLocationIdx) % homePartitionNumLocations;
     int homeX = homePartitionStartX + localPersonIdx % locationPartitionWidth;
     int homeY = homePartitionStartY + localPersonIdx / locationPartitionWidth;
-    
-    //int personGridX = personIdx % locationPartitionWidth;
-    //int personGridY = personIdx / locationPartitionHeight;
-
-    //int homeX = personGridX / peoplePerLocationX;
-    //int homeY = personGridY / peoplePerLocationY;
 
     // Get random number of visits for this person.
     int numVisits = num_visits_generator(generator);
@@ -222,7 +209,6 @@ void People::SyntheticSendVisitMessages() {
       // Get number of locations away this person should visit.
       int numHops = std::min(visit_distance_generator(generator),
         synLocationGridWidth + synLocationGridHeight - 2);
-      //CkPrintf("visiting a location %d hops away \r\n", numHops);
 
       int destinationOffsetX = 0;
       int destinationOffsetY = 0;
@@ -241,13 +227,9 @@ void People::SyntheticSendVisitMessages() {
             synLocationGridHeight - 1 - homeY
         );
        
-        //CkPrintf("max hops +x: %d, -x: %d, +y: %d, -y: %d, grid is %d by %d\r\n",
-          //maxHopsPositiveX, maxHopsNegativeX, maxHopsPositiveY, maxHopsNegativeY, synLocationGridWidth, synLocationGridHeight); 
-
         // Choose random number of hops in the X direction.
         std::uniform_int_distribution<int> dist_gen(-maxHopsNegativeX, maxHopsPositiveX);
         destinationOffsetX = dist_gen(generator);
-        //CkPrintf("offset x %d\r\n", destinationOffsetX);
 
         // Travel the remaining hops in the Y direction
         numHops -= std::abs(destinationOffsetX);
@@ -266,14 +248,8 @@ void People::SyntheticSendVisitMessages() {
       }
 
       // Finally calculate the index of the location to actually visit...
-      int destinationIdx = (homeX + destinationOffsetX)
-                          + (homeY + destinationOffsetY) * synLocationGridWidth;
       int destinationX = homeX + destinationOffsetX;
       int destinationY = homeY + destinationOffsetY;
-      //CkPrintf(
-      //  "person %d will visit location (%d, %d) with offset (%d,%d)\r\n",
-      //  personIdx, destinationX, destinationY, destinationOffsetX, destinationOffsetY);
-      /*
 
       // ...and translate it from 2D to 1D, respecting the 2D distribution
       // of the locations across partitions
@@ -283,10 +259,7 @@ void People::SyntheticSendVisitMessages() {
           (destinationX % locationPartitionWidth)
         + (destinationY % locationPartitionHeight) * locationPartitionWidth
         + partitionX * numLocationsPerPartition
-        + partitionY * synLocationGridWidth * numLocationsPerPartition;
-      CkPrintf("(%d, %d) -> %d in partition (%d, %d)\r\n",
-         destinationX, destinationY, destinationIdx, partitionX, partitionY);
-      */
+        + partitionY * locationPartitionGridWidth * numLocationsPerPartition;
 
       // Determine which chare tracks this location.
       int locationPartition = getPartitionIndex(

--- a/src/People.h
+++ b/src/People.h
@@ -25,6 +25,7 @@ class People : public CBase_People {
     int numLocalPeople;
     int day;
     int newCases;
+    int totalVisitsForDay;
 
     std::ifstream *activityData;
     std::vector<Person> people;

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -34,6 +34,10 @@ mainmodule loimos {
   readonly int synPeopleGridHeight;
   readonly int synLocationGridWidth;
   readonly int synLocationGridHeight;
+  readonly int synLocalLocationGridWidth;
+  readonly int synLocalLocationGridHeight;
+  readonly int synLocationPartitionGridWidth;
+  readonly int synLocationPartitionGridHeight;
   readonly int averageDegreeOfVisit;
 
   mainchare Main {

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -25,8 +25,14 @@ mainmodule loimos {
   readonly int firstLocationIdx;
   readonly std::string scenarioPath;
   readonly std::string scenarioId;
-  
+
   readonly double simulationStartTime;
+
+  readonly int synPeopleGridWidth;
+  readonly int synPeopleGridHeight;
+  readonly int synLocationGridWidth;
+  readonly int synLocationGridHeight;
+  readonly int averageDegreeOfVisit;
 
   mainchare Main {
     entry Main(CkArgMsg*);

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -26,7 +26,9 @@ mainmodule loimos {
   readonly std::string scenarioPath;
   readonly std::string scenarioId;
 
+  readonly uint64_t totalVisits;
   readonly double simulationStartTime;
+  readonly double iterationStartTime;
 
   readonly int synPeopleGridWidth;
   readonly int synPeopleGridHeight;
@@ -39,6 +41,7 @@ mainmodule loimos {
     entry void run() {
       for(day = 0; day < numDays; day++) {
         serial {
+          iterationStartTime = CkWallTimer();
           // CkPrintf("Sending Visit Messages\n");
           peopleArray.SendVisitMessages();
           // CkPrintf("QD Visit Messages\n");
@@ -67,9 +70,14 @@ mainmodule loimos {
         when ReceiveStats(CkReductionMsg *summary) {
           serial {
             CkPrintf("Summary of Day %d\n", day);
+            CkPrintf("Iteration %d Execution Time: %lf seconds.\n", day, CkWallTimer() - iterationStartTime);
             int *data = reinterpret_cast<int *>(summary->getData());
-            DiseaseModel* diseaseModel = globDiseaseModel.ckLocalBranch();
+            // Get total visits for the day.
+            totalVisits += *data;
+            data++;
 
+            // Get number of disease state changes.
+            DiseaseModel* diseaseModel = globDiseaseModel.ckLocalBranch();
             for (int i = 0; i < diseaseModel->getNumberOfStates(); i++) {
               int total_in_state = *data;
               int change_in_infected = total_in_state - accumulated[i];
@@ -90,6 +98,7 @@ mainmodule loimos {
       serial { 
         printf("Finished data loading in %lf seconds.\n", simulationStartTime);
         printf("Finished simulation in %lf seconds.\n", (CkWallTimer() - simulationStartTime));
+        printf("Total Visits Processed %llu.\n", totalVisits);
         CkExit(); 
       }
     };


### PR DESCRIPTION
Introduces notion of grid based synthetic visits. We map the population in two grids: a people grid and a location grid. The grids are of size P_x by P_y and of L_x and L_y. We additionally specify an average degree of visit in the command line. 

Each person has a non-unique home location based on a linear mapping from the people grid to the location grid. On each day, each person chooses a random number of visits with random visit times. They then select a random distance to visit away from their home location (may be zero) and choose a random direction to fulfill that distance. For home location close to a grid border, these visits might get cropped.