### PR TITLE
Process Events Bugfix

### DIFF
--- a/src/Location.C
+++ b/src/Location.C
@@ -44,7 +44,7 @@ void Location::processEvents(
   std::vector<Event> *arrivals;
   
   std::sort(events.begin(), events.end());
-  for (Event event: events) {
+  for (const Event &event: events) {
     if (diseaseModel->isSusceptible(event.personState)) {
       arrivals = &susceptibleArrivals;
 

--- a/src/Locations.C
+++ b/src/Locations.C
@@ -128,7 +128,7 @@ void Locations::ReceiveVisitMessages(VisitMessage visitMsg) {
 
 void Locations::ComputeInteractions() {
   // traverses list of locations
-  for (Location loc : locations) {
+  for (Location &loc : locations) {
     loc.processEvents(diseaseModel, contactModel);
   }
 }


### PR DESCRIPTION
switched to itnerating over references instead of values when processing events, which fixes a problem where we called processEvents on a copy of each Location and the changes make to the queue weren't reflected in the persistent object