### PR TITLE
Introduces more realistic synthetic visit parameters

### DIFF
--- a/src/Defs.h
+++ b/src/Defs.h
@@ -36,7 +36,9 @@ const Time MINUTE_LENGTH = 60;
 #define EMPTY_VISIT_SCHEDULE 0xFFFFFFFF
 #define CSV_DELIM ','
 
-#define PEOPLE_SEEDING true
+#ifndef PEOPLE_SEEDING
+  #define PEOPLE_SEEDING true
+#endif // PEOPLE_SEEDING
 #define INITIAL_PERSON_INFECTIOUS_PROB 0.01
 // Location seeding options
 #define PERCENTAGE_OF_SEEDING_LOCATIONS 0.001

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -36,9 +36,16 @@ const Time MINUTE_LENGTH = 60;
 #define EMPTY_VISIT_SCHEDULE 0xFFFFFFFF
 #define CSV_DELIM ','
 
+#define PEOPLE_SEEDING true
+#define INITIAL_PERSON_INFECTIOUS_PROB 0.01
+// Location seeding options
 #define PERCENTAGE_OF_SEEDING_LOCATIONS 0.001
 #define INITIAL_INFECTIOUS_PROBABILITY 0.01
 #define DAYS_TO_SEED_INFECTION 3
+
+// Synthetic configuration
+#define PEOPLE_PEOPLE_DEGREE 40
+#define AVERAGE_REAL_WORLD_VISIT_DISTANCE 50.00
 
 extern /* readonly */ CProxy_Main mainProxy;
 extern /* readonly */ CProxy_People peopleArray;
@@ -70,7 +77,8 @@ extern /* readonly */ int synLocalLocationGridWidth;
 extern /* readonly */ int synLocalLocationGridHeight;
 extern /* readonly */ int synLocationPartitionGridWidth;
 extern /* readonly */ int synLocationPartitionGridHeight;
-extern /* readonly */ int averageDegreeOfVisit;
+extern /* readonly */ double averageDistanceOfVisit;
+extern /* readonly */ double averageVisitsPerDay;
 
 int getNumElementsPerPartition(int numElements, int numPartitions);
 

--- a/src/Location.C
+++ b/src/Location.C
@@ -25,24 +25,25 @@ Location::Location(int numAttributes, int uniqueIdx, std::default_random_engine 
   this->generator = generator;
 
   // Determine if this location should seed the disease.
-  if (syntheticRun) {
-    // For synthetic runs start seed in corner.
-    // Determine grid size in each corner s.t. randomly selecting 50%
-    // of these locations will result
-    int seedSize = 
-      std::max((int) std::sqrt((numLocations * PERCENTAGE_OF_SEEDING_LOCATIONS) / 4), 1);
-    
-    int locationX = uniqueIdx % synLocationGridWidth;
-    int locationY = uniqueIdx / synLocationGridWidth;
-    if ((locationX < seedSize || (synLocationGridWidth - locationX) <= seedSize)
-        && (locationY < seedSize || (synLocationGridHeight - locationY) <= seedSize)) {
-      isDiseaseSeeder = true;
+  if (!PEOPLE_SEEDING) {
+    if (syntheticRun) {
+      // For synthetic runs start seed in corner.
+      // Determine grid size in each corner s.t. randomly selecting 50%
+      // of these locations will result
+      int seedSize = 
+        std::max((int) std::sqrt((numLocations * PERCENTAGE_OF_SEEDING_LOCATIONS) / 4), 1);
+      
+      int locationX = uniqueIdx % synLocationGridWidth;
+      int locationY = uniqueIdx / synLocationGridWidth;
+      if ((locationX < seedSize || (synLocationGridWidth - locationX) <= seedSize)
+          && (locationY < seedSize || (synLocationGridHeight - locationY) <= seedSize)) {
+        isDiseaseSeeder = true;
+      }
+    } else {
+      // For non-synthetic set just seed completely at random.
+      isDiseaseSeeder = uniform_dist(*generator) < PERCENTAGE_OF_SEEDING_LOCATIONS;
     }
-  } else {
-    // For non-synthetic set just seed completely at random.
-    isDiseaseSeeder = uniform_dist(*generator) < PERCENTAGE_OF_SEEDING_LOCATIONS;
   }
-  
 }
 
 // DataInterface overrides. 
@@ -200,7 +201,7 @@ inline void Location::sendInteractions(int personIdx) {
   );
 
   // Randomly seed some people for infection.
-  if (isDiseaseSeeder && day < DAYS_TO_SEED_INFECTION 
+  if (!PEOPLE_SEEDING && isDiseaseSeeder && day < DAYS_TO_SEED_INFECTION 
       && uniform_dist(*generator) < INITIAL_INFECTIOUS_PROBABILITY) {
         // Add a super contagious visit for that person.
         interactions[personIdx].emplace_back(

--- a/src/Main.C
+++ b/src/Main.C
@@ -70,9 +70,8 @@ Main::Main(CkArgMsg* msg) {
     assert(synPeopleGridHeight >= synLocationGridHeight);
 
     // Edge degree.
-    int physicalDistanceBetweenLocations = atoi(msg->argv[6]);
-    averageDistanceOfVisit = AVERAGE_REAL_WORLD_VISIT_DISTANCE / physicalDistanceBetweenLocations;
-    
+    averageDistanceOfVisit = atof(msg->argv[6]);
+
     // Chare data
     synLocationPartitionGridWidth = atoi(msg->argv[7]);
     synLocationPartitionGridHeight = atoi(msg->argv[8]);

--- a/src/Main.C
+++ b/src/Main.C
@@ -45,7 +45,8 @@
 /* readonly */ int synLocalLocationGridHeight;
 /* readonly */ int synLocationPartitionGridWidth;
 /* readonly */ int synLocationPartitionGridHeight;
-/* readonly */ int averageDegreeOfVisit;
+/* readonly */ double averageVisitsPerDay;
+/* readonly */ double averageDistanceOfVisit;
 
 
 Main::Main(CkArgMsg* msg) {
@@ -69,7 +70,8 @@ Main::Main(CkArgMsg* msg) {
     assert(synPeopleGridHeight >= synLocationGridHeight);
 
     // Edge degree.
-    averageDegreeOfVisit = atoi(msg->argv[6]);
+    int physicalDistanceBetweenLocations = atoi(msg->argv[6]);
+    averageDistanceOfVisit = AVERAGE_REAL_WORLD_VISIT_DISTANCE / physicalDistanceBetweenLocations;
     
     // Chare data
     synLocationPartitionGridWidth = atoi(msg->argv[7]);
@@ -97,6 +99,7 @@ Main::Main(CkArgMsg* msg) {
         synLocationGridWidth, synLocationGridHeight);
     }
 
+    averageVisitsPerDay = PEOPLE_PEOPLE_DEGREE * (numPeople / numLocations);
     baseRunInfo = 9;
   } else {
     numPeople = atoi(msg->argv[2]);
@@ -137,7 +140,7 @@ Main::Main(CkArgMsg* msg) {
   mainProxy = thisProxy;
 
   if(syntheticRun) {
-    CkPrintf("Synthetic run with (%d, %d) person grid and (%d, %d) location grid. Average degree of %d\n\n", synPeopleGridWidth, synPeopleGridHeight, synLocationGridWidth, synLocationGridHeight, averageDegreeOfVisit);
+    CkPrintf("Synthetic run with (%d, %d) person grid and (%d, %d) location grid. Average of %lf visits per day with distance %lf\n\n", synPeopleGridWidth, synPeopleGridHeight, synLocationGridWidth, synLocationGridHeight, averageVisitsPerDay, averageDistanceOfVisit);
   }
 
   // Instantiate DiseaseModel nodegroup (One for each physical processor).

--- a/src/Makefile
+++ b/src/Makefile
@@ -63,7 +63,7 @@ test-small: all
 	./charmrun +p4 ./loimos 0 100 735 2 2 7 test-small.csv ../data/disease_models/covid19.textproto ../data/populations/synthetic_small_city/ ++local
 
 test-syn: all
-	./charmrun +p4 ./loimos 1 100 100 50 50 5 5 5 32 30 test-syn.csv ../data/disease_models/covid19_onepath.textproto ++local
+	./charmrun +p4 ./loimos 1 100 100 50 50 10 5 5 32 30 test-syn.csv ../data/disease_models/covid19_onepath.textproto ++local
 
 test-large: all
 	./charmrun +p4 ./loimos 0 41119 19203 60 40 7 test-large.csv ../data/disease_models/covid19.textproto ../data/populations/coc/ --min-max-alpha ++local

--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -8,6 +8,5 @@ PROTOBUF_HOME ?= /usr/local/protobuf
 PROTOC        = $(PROTOBUF_HOME)/bin/protoc
 
 CXX       = g++
-OPTS      = -g -O2
+OPTS      += -g -O2
 CXXFLAGS  = $(OPTS) -std=c++11 -Wall -I$(PROTOBUF_HOME)/include
-

--- a/src/People.h
+++ b/src/People.h
@@ -18,8 +18,6 @@
 #include <iostream>
 #include <fstream>
 
-#define LOCATION_LAMBDA 5.2
-
 class People : public CBase_People {
   private:
     int numLocalPeople;

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -38,7 +38,8 @@ mainmodule loimos {
   readonly int synLocalLocationGridHeight;
   readonly int synLocationPartitionGridWidth;
   readonly int synLocationPartitionGridHeight;
-  readonly int averageDegreeOfVisit;
+  readonly double averageDistanceOfVisit;
+  readonly double averageVisitsPerDay;
 
   mainchare Main {
     entry Main(CkArgMsg*);


### PR DESCRIPTION
* Changes average distance of visit parameter to be a physical distance between locations. Average number of visits is now based off of a constant 50 miles average visit distance divided by distance between locations
* Average number of visits per day is now equal to the PEOPLE_PEOPLE_DEGREE * ratio(people to locations)
* Adds back uniform people seeding for scalability studies