### PR TITLE
Cache 32 to 64 bit

### DIFF
--- a/src/Locations.C
+++ b/src/Locations.C
@@ -94,9 +94,9 @@ void Locations::loadLocationData() {
   }
   
   // Find starting line for our data through location cache.
-  locationCache.seekg(thisIndex * sizeof(uint32_t));
-  uint32_t locationOffset;
-  locationCache.read((char *) &locationOffset, sizeof(uint32_t));
+  locationCache.seekg(thisIndex * sizeof(uint64_t));
+  uint64_t locationOffset;
+  locationCache.read((char *) &locationOffset, sizeof(uint64_t));
   locationData.seekg(locationOffset);
 
   // Read in our location data.

--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -32,6 +32,10 @@ LIBS += -L$(PROTOBUF_HOME)/lib
 endif
 
 # Set the ENABLE_UNIT_TESTING environment variable to compile for unit testing
+ifdef ENABLE_DEBUG
+OPTS     += -DENABLE_DEBUG
+endif
+
 ifdef ENABLE_UNIT_TESTING
 INCLUDES +=	-I$(GTEST_HOME)/include
 LIBS     += -L$(GTEST_HOME)/lib -lgtest

--- a/src/People.C
+++ b/src/People.C
@@ -102,9 +102,9 @@ void People::loadPeopleData() {
   }
 
   // Find starting line for our data through people cache.
-  peopleCache.seekg(thisIndex * sizeof(uint32_t));
-  uint32_t peopleOffset;
-  peopleCache.read((char *) &peopleOffset, sizeof(uint32_t));
+  peopleCache.seekg(thisIndex * sizeof(uint64_t));
+  uint64_t peopleOffset;
+  peopleCache.read((char *) &peopleOffset, sizeof(uint64_t));
   peopleData.seekg(peopleOffset);
 
   // Read in from remote file.
@@ -120,15 +120,15 @@ void People::loadPeopleData() {
   }
 
   // Load preprocessing meta data.
-  uint32_t *buf = (uint32_t *) malloc(sizeof(uint32_t) * numDaysWithRealData);
+  uint64_t *buf = (uint64_t *) malloc(sizeof(uint64_t) * numDaysWithRealData);
   for (int c = 0; c < numLocalPeople; c++) {
-    std::vector<uint32_t> *data_pos = &people[c].visitOffsetByDay;
+    std::vector<uint64_t> *data_pos = &people[c].visitOffsetByDay;
     int curr_id = people[c].uniqueId;
 
     // Read in their activity data offsets.
-    activityCache.seekg(sizeof(uint32_t) * numDaysWithRealData
+    activityCache.seekg(sizeof(uint64_t) * numDaysWithRealData
        * (curr_id - firstPersonIdx));
-    activityCache.read((char *) buf, sizeof(uint32_t) * numDaysWithRealData);
+    activityCache.read((char *) buf, sizeof(uint64_t) * numDaysWithRealData);
     for (int day = 0; day < numDaysWithRealData; day++) {
       data_pos->push_back(buf[day]);
     }
@@ -153,7 +153,7 @@ void People::loadVisitData(std::ifstream *activityData) {
     for (Person &person: people) {
       
       // Seek to correct position in file.
-      uint32_t seekPos = person
+      uint64_t seekPos = person
         .visitOffsetByDay[day % numDaysWithRealData];
       if (seekPos == EMPTY_VISIT_SCHEDULE) {
         //CkPrintf("No visits on day %d in people chare %d\n", day, thisIndex);

--- a/src/Person.C
+++ b/src/Person.C
@@ -24,7 +24,7 @@ Person::Person(int numAttributes, int startingState, int timeLeftInState) {
     this->isIsolating = false;
     this->willComply = false;
     this->secondsLeftInState = timeLeftInState;
-    this->visitOffsetByDay = std::vector<uint32_t>();
+    this->visitOffsetByDay = std::vector<uint64_t>();
 
     // Create an entry for each day we have data for    
     this->visitsByDay = std::vector<std::vector<VisitMessage> >();

--- a/src/Person.h
+++ b/src/Person.h
@@ -30,7 +30,7 @@ class Person : public DataInterface {
         // Integer byte offsets in visits file by day.
         // For example, fseek(visitOffsetByDay[2]) would seek to the start
         // of this person's visits on day 3.
-        std::vector<uint32_t> visitOffsetByDay;
+        std::vector<uint64_t> visitOffsetByDay;
 
         // Holds visit messages for each day
         std::vector<std::vector<VisitMessage> > visitsByDay;

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -189,6 +189,11 @@ mainmodule loimos {
     entry void SeedInfections();
     entry void StartComputingInteractions(); 
     entry void ComputedInteractions();
+    #ifdef ENABLE_DEBUG
+    entry [reductiontarget] void ReceiveVisitsCount(int visitsCount) {
+        serial{CkPrintf("  Loaded a total of %d visits\n", visitsCount);}
+    };
+    #endif // ENABLE_DEBUG
     entry [reductiontarget] void ReceiveInfectiousCount(int infectiousCount);
     entry [reductiontarget] void ReceiveStats(CkReductionMsg *summary);
     #ifdef USE_PROJECTIONS

--- a/src/readers/Preprocess.C
+++ b/src/readers/Preprocess.C
@@ -77,7 +77,7 @@ int buildObjectLookupCache(std::string inputPath, std::string outputPath, int nu
     std::string line;
     // Clear header.
     std::getline(activityStream, line);
-    uint32_t currentPosition = activityStream.tellg();;
+    uint64_t currentPosition = activityStream.tellg();;
 
     // Special case to get lowest person ID first.
     std::getline(activityStream, line);
@@ -100,7 +100,7 @@ int buildObjectLookupCache(std::string inputPath, std::string outputPath, int nu
         std::ofstream outputStream(outputPath, std::ios_base::binary);
         for (int chareNum = 0; chareNum < numChares; chareNum++) {
             // Write current offset.
-            outputStream.write((char *) &currentPosition, sizeof(uint32_t));
+            outputStream.write((char *) &currentPosition, sizeof(uint64_t));
 
             // Skip next n lines.
             for (int i = 0; i < objPerChare; i++) {
@@ -143,8 +143,8 @@ void buildActivityCache(std::string inputPath, std::string outputPath, int numPe
     csvConfigDefStream.close();
 
     // Create position vector for each person.
-    std::size_t totalDataSize = numPeople * DAYS_IN_WEEK * sizeof(uint32_t);
-    uint32_t *elements = (uint32_t *) malloc(totalDataSize);
+    std::size_t totalDataSize = numPeople * DAYS_IN_WEEK * sizeof(uint64_t);
+    uint64_t *elements = (uint64_t *) malloc(totalDataSize);
     if (elements == NULL) {
         CkAbort("Failed to malloc enoough memory for preprocessing.\n");
     }
@@ -154,7 +154,7 @@ void buildActivityCache(std::string inputPath, std::string outputPath, int numPe
     std::string line;
     // Clear header.
     std::getline(activityStream, line);
-    uint32_t current_position = activityStream.tellg();
+    uint64_t current_position = activityStream.tellg();
     int lastPerson = -1;
     int lastTime = -1;
     int nextPerson = 0;


### PR DESCRIPTION
Converts cache to use 64 bit unsigned integers rather than 32 bit ones in order to avoid integer overflow/truncation errors on the visit offsets. Also added debug code to count and print the total number of loaded visits.