### PR TITLE
Visit messages bugfix

### DIFF
--- a/src/Main.C
+++ b/src/Main.C
@@ -387,6 +387,9 @@ void Main::SeedInfections() {
     }
   }
 
+  int dayIdx = day % numDaysWithRealData;
+  int dayStart = day * DAY_LENGTH;
+  int dayEnd = dayStart + DAY_LENGTH - 1;
   for (int i = 0; i < INITIAL_INFECTIONS_PER_DAY; ++i) {
     int personIdx = initialInfections.back();
     initialInfections.pop_back();
@@ -402,10 +405,10 @@ void Main::SeedInfections() {
     std::vector<Interaction> interactions;
     interactions.emplace_back(
       std::numeric_limits<double>::max(),
-      0,
-      0,
-      0,
-      std::numeric_limits<int>::max()
+      -1,
+      -1,
+      dayStart,
+      dayEnd
     );
 
     InteractionMessage interMsg(-1, personIdx, interactions);

--- a/src/People.h
+++ b/src/People.h
@@ -31,6 +31,7 @@ class People : public CBase_People {
     DiseaseModel *diseaseModel;
     std::vector<int> stateSummaries;
 
+    void SendVisitMessage(VisitMessage *visitMessage);
     void ProcessInteractions(Person &person);
     void loadPeopleData();
     void loadVisitData(std::ifstream *activityData);
@@ -38,7 +39,7 @@ class People : public CBase_People {
     People();
     People(CkMigrateMessage *msg);
     void pup(PUP::er &p);
-    void SendVisitMessages(); 
+    void SendVisitMessages();
     void SyntheticSendVisitMessages();
     void RealDataSendVisitMessages();
     void ReceiveInteractions(InteractionMessage interMsg);

--- a/src/People.h
+++ b/src/People.h
@@ -31,6 +31,8 @@ class People : public CBase_People {
     DiseaseModel *diseaseModel;
     std::vector<int> stateSummaries;
 
+    void ComputeVisitDiseaseState(int dayStart, const Person &person,
+        VisitMessage *visitMessage);
     void SendVisitMessage(VisitMessage *visitMessage);
     void ProcessInteractions(Person &person);
     void loadPeopleData();
@@ -40,8 +42,8 @@ class People : public CBase_People {
     People(CkMigrateMessage *msg);
     void pup(PUP::er &p);
     void SendVisitMessages();
-    void SyntheticSendVisitMessages();
-    void RealDataSendVisitMessages();
+    void ComputeVisits();
+    void SendLoadedVisits();
     void ReceiveInteractions(InteractionMessage interMsg);
     void EndOfDayStateUpdate();
     void SendStats();

--- a/src/Person.C
+++ b/src/Person.C
@@ -20,7 +20,7 @@ Person::Person(int numAttributes, int startingState, int timeLeftInState) {
         this->personData.resize(numAttributes);
     }
     this->state = startingState;
-    this->next_state = -1;
+    this->nextState = -1;
     this->isIsolating = false;
     this->willComply = false;
     this->secondsLeftInState = timeLeftInState;
@@ -33,7 +33,7 @@ Person::Person(int numAttributes, int startingState, int timeLeftInState) {
 void Person::pup(PUP::er &p) {
     p | uniqueId;
     p | state;
-    p | next_state;
+    p | nextState;
     p | secondsLeftInState;
     p | interactions;
     p | visitOffsetByDay;
@@ -56,9 +56,9 @@ void Person::EndOfDayStateUpdate(DiseaseModel *diseaseModel,
   secondsLeftInState -= DAY_LENGTH;
   if (secondsLeftInState <= 0) {
     // If they have already been infected
-    if (next_state != -1) {
-      state = next_state;
-      std::tie(next_state, secondsLeftInState) =
+    if (nextState != -1) {
+      state = nextState;
+      std::tie(nextState, secondsLeftInState) =
         diseaseModel->transitionFromState(state, generator);
 
       // Check if person will begin isolating.
@@ -71,7 +71,7 @@ void Person::EndOfDayStateUpdate(DiseaseModel *diseaseModel,
       std::tie(state, std::ignore) =
         diseaseModel->transitionFromState(state, generator);
       // See where they will transition next.
-      std::tie(next_state, secondsLeftInState) =
+      std::tie(nextState, secondsLeftInState) =
         diseaseModel->transitionFromState(state, generator);
     }
   }

--- a/src/Person.C
+++ b/src/Person.C
@@ -54,9 +54,14 @@ std::vector<union Data> &Person::getDataField() {
 
 void Person::EndOfDayStateUpdate(DiseaseModel *diseaseModel,
     std::default_random_engine *generator) {
-  // Transition to next state or mark the passage of time
+  // We use the max time to mark states which last indefintiely
+  if (std::numeric_limits<Time>::max() == secondsLeftInState) {
+    return;
+  }
   secondsLeftInState -= DAY_LENGTH;
+
   int dwellTime = 0;
+  int oldState = state;
   if (secondsLeftInState <= 0) {
     // If they have already been infected
     if (nextState != -1) {
@@ -77,7 +82,16 @@ void Person::EndOfDayStateUpdate(DiseaseModel *diseaseModel,
       std::tie(nextState, dwellTime) =
         diseaseModel->transitionFromState(state, generator);
     }
-    secondsLeftInState += dwellTime;
+
+    // We use the max time to mark states which last indefintiely, so don't
+    // mess that up
+    if (std::numeric_limits<Time>::max() == dwellTime) {
+      secondsLeftInState = dwellTime;
+    } else {
+      secondsLeftInState += dwellTime;
+    }
+    CkPrintf("  Person %d transitioned from %d to %d (%d/%ds left, next %d)\n",
+        uniqueId, oldState, state, secondsLeftInState, dwellTime, nextState);
   }
 }
 

--- a/src/Person.C
+++ b/src/Person.C
@@ -11,6 +11,8 @@
 #include "Message.h"
 #include "readers/data.pb.h"
 
+#include <random>
+
 /**
  * Defines attributes of a single person.
  */
@@ -54,11 +56,12 @@ void Person::EndOfDayStateUpdate(DiseaseModel *diseaseModel,
     std::default_random_engine *generator) {
   // Transition to next state or mark the passage of time
   secondsLeftInState -= DAY_LENGTH;
+  int dwellTime = 0;
   if (secondsLeftInState <= 0) {
     // If they have already been infected
     if (nextState != -1) {
       state = nextState;
-      std::tie(nextState, secondsLeftInState) =
+      std::tie(nextState, dwellTime) =
         diseaseModel->transitionFromState(state, generator);
 
       // Check if person will begin isolating.
@@ -70,10 +73,11 @@ void Person::EndOfDayStateUpdate(DiseaseModel *diseaseModel,
       // Get which exposed state they should transition to.
       std::tie(state, std::ignore) =
         diseaseModel->transitionFromState(state, generator);
-      // See where they will transition next.
-      std::tie(nextState, secondsLeftInState) =
+      // See where they will transition next
+      std::tie(nextState, dwellTime) =
         diseaseModel->transitionFromState(state, generator);
     }
+    secondsLeftInState += dwellTime;
   }
 }
 

--- a/src/Person.h
+++ b/src/Person.h
@@ -18,7 +18,7 @@ class Person : public DataInterface {
         int uniqueId;
         // Numeric disease state of the person.
         int state;
-        int next_state;
+        int nextState;
         int secondsLeftInState;
         bool willComply;
         bool isIsolating;
@@ -34,7 +34,7 @@ class Person : public DataInterface {
 
         // Holds visit messages for each day
         std::vector<std::vector<VisitMessage> > visitsByDay;
-        
+
         // Various dynamic attributes of the person
         std::vector<union Data> personData;
 

--- a/src/Person.h
+++ b/src/Person.h
@@ -52,7 +52,7 @@ class Person : public DataInterface {
 
         // Disease model functions.
         void EndOfDayStateUpdate(DiseaseModel *diseaseModel,
-                                   std::default_random_engine *generator);
+            std::default_random_engine *generator);
 
         // Override DataInterfect abstract methods
         void setUniqueId(int idx);


### PR DESCRIPTION
- Fixed issue were we weren't correctly handling the times of disease state transitions within a single day
- Now send pre-transition states for any visits which end before the transition, post-transition states for visits which start after the transition, and split visits that span both sides of a transition
- Also fixed how we calculate transition times
- Now randomly select a time during a interaction which causes the infection as the exposure time
- Now calculate transition times by adding dwell time to difference between day length and when in the day the transition should have occurred (can change which day transitions occur on)