### PR TITLE
License year update

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2020 The Loimos Project Developers.
+Copyright 2020-2023 The Loimos Project Developers.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/src/Aggregator.C
+++ b/src/Aggregator.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Aggregator.h
+++ b/src/Aggregator.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/AggregatorParam.h
+++ b/src/AggregatorParam.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Defs.C
+++ b/src/Defs.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -11,27 +11,27 @@
 #include <cmath>
 
 /**
- * Returns the number of elements that each chare will track at a minimum. 
- * 
+ * Returns the number of elements that each chare will track at a minimum.
+ *
  * Args:
  *    int numElements: The total number of objects of this type.
  *    int numPartitions: The total number of chares.
- * 
- */ 
+ *
+ */
 int getNumElementsPerPartition(int numElements, int numPartitions){
   return floor((float)numElements/(float)numPartitions);
 }
 
 
 /**
- * Returns the number of the objects that a particular chare tracks. 
- * 
+ * Returns the number of the objects that a particular chare tracks.
+ *
  * Args:
  *    int numElements: The total number of objects of this type.
  *    int numPartitions: The total number of chares.
  *    int partitionIndex: Chare index
- * 
- */ 
+ *
+ */
 int getNumLocalElements(int numElements, int numPartitions, int partitionIndex){
   int elementsPerPartition = getNumElementsPerPartition(numElements,numPartitions);
   if(partitionIndex == (numPartitions-1))
@@ -40,17 +40,17 @@ int getNumLocalElements(int numElements, int numPartitions, int partitionIndex){
 }
 
 /**
- * Returns the number of the chare that tracks a particular element. 
- * 
+ * Returns the number of the chare that tracks a particular element.
+ *
  * Args:
  *    int globalIndex: The global unique object identifier.
  *    int numElements: The total number of objects of this type.
  *    int numPartitions: The total number of chares.
  *    int offset: The globalIndex number referring to the first object. Likely
  *      could be replaced with a better system.
- * 
+ *
  * Notes: Will likely change as we introduce active load balancing.
- */ 
+ */
 int getPartitionIndex(int globalIndex, int numElements, int numPartitions, int offset){
   int partitionIndex = (globalIndex - offset) /getNumElementsPerPartition(numElements,numPartitions);
   if(partitionIndex >= numPartitions)
@@ -61,15 +61,15 @@ int getPartitionIndex(int globalIndex, int numElements, int numPartitions, int o
 /**
  * Returns local (zero-indexed) position of an object on a chare from its
  * global id.
- * 
+ *
  * Args:
  *    int globalIndex: The global unique object identifier.
  *    int numElements: The total number of objects of this type.
  *    int numPartitions: The total number of chares.
  *    int offset: The globalIndex number referring to the first object. Likely
  *      could be replaced with a better system.
- * 
- */ 
+ *
+ */
 int getLocalIndex(int globalIndex, int numElements, int numPartitions, int offset){
   int partitionIndex = getPartitionIndex(globalIndex,numElements,numPartitions, offset);
   int elementsPerPartition = getNumElementsPerPartition(numElements,numPartitions);
@@ -79,15 +79,15 @@ int getLocalIndex(int globalIndex, int numElements, int numPartitions, int offse
 /**
  * Returns global indexed position of an object from its local (zero-indexed)
  * id on a chare.
- * 
+ *
  * Args:
  *    int localIndex: The local (zero-indexed) unique object identifier.
  *    int numElements: The total number of objects of this type.
  *    int numPartitions: The total number of chares.
  *    int offset: The globalIndex number referring to the first object. Likely
  *      could be replaced with a better system.
- * 
- */ 
+ *
+ */
 int getGlobalIndex(int localIndex, int partitionIndex, int numElements, int numPartitions, int offset){
   int elementsPerPartition = getNumElementsPerPartition(numElements,numPartitions);
   return partitionIndex*elementsPerPartition+localIndex + offset;

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/DiseaseModel.C
+++ b/src/DiseaseModel.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/DiseaseModel.h
+++ b/src/DiseaseModel.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Event.C
+++ b/src/Event.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -6,7 +6,7 @@
 
 #include "loimos.decl.h"
 #include "Event.h"
-  
+
 // This is just so that we can order Events in the Location queues
 bool Event::operator<(const Event& rhs) const {
   // First compare times...

--- a/src/Event.h
+++ b/src/Event.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Interaction.C
+++ b/src/Interaction.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -6,7 +6,7 @@
 
 #include "loimos.decl.h"
 #include "Interaction.h"
-  
+
 Interaction::Interaction(
   double propensity,
   int infectiousIdx,

--- a/src/Interaction.h
+++ b/src/Interaction.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -20,13 +20,13 @@ struct Interaction {
   // a infection
   // TODO: figure out how to extract these from an infectious/susceptible
   // state pair
-  //int targetState; 
+  //int targetState;
   // We need to know when the interaction occured so that, if this interaction
   // does in fact result in an infection, we can determine precisely when it
   // occured
   int startTime;
   int endTime;
-  
+
   // Lets us send potential infections via charm++
   void pup(PUP::er &p);
 

--- a/src/Location.C
+++ b/src/Location.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Location.h
+++ b/src/Location.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -36,7 +36,7 @@ class Location : public DataInterface {
     // a person currently at this location
     std::vector<Event> infectiousArrivals;
     std::vector<Event> susceptibleArrivals;
-    
+
     // Maps each susceptible person's id to a list of interactions with people
     // who could have infected them
     std::unordered_map<int, std::vector<Interaction> > interactions;
@@ -46,7 +46,7 @@ class Location : public DataInterface {
 
     bool complysWithShutdown;
     int day;
-   
+
     // For DataInterface
     int uniqueId;
 
@@ -87,12 +87,12 @@ class Location : public DataInterface {
     // Represents all of the arrivals and departures of people
     // from this location on a given day
     std::vector<Event> events;
-    
+
     // This distribution should always be the same - not sure how well
     // static variables work with Charm++, so this may need to be put
     // on the stack somewhere later on
     // static std::uniform_real_distribution<> unitDistrib;
-    
+
     // Provide default constructor operations.
     Location() = default;
     Location(CkMigrateMessage *msg);
@@ -105,19 +105,19 @@ class Location : public DataInterface {
     // Default assignment operators.
     Location& operator=(const Location&) = default;
     Location& operator=(Location&&) = default;
-   
-    // Lets us migrate these objects 
+
+    // Lets us migrate these objects
     void pup(PUP::er &p);
     void setGenerator(std::default_random_engine *generator);
 
     // Override abstract DataInterface getters and setters.
     void setUniqueId(int idx);
     std::vector<union Data> &getDataField();
-    
+
     // Adds an event represnting a person either arriving or departing
     // from this location
     void addEvent(Event e);
-    
+
     // Runs through all of the current events and return the indices of
     // any people who have been infected
     void processEvents(
@@ -125,5 +125,5 @@ class Location : public DataInterface {
       ContactModel *contactModel
     );
 };
-  
+
 #endif // __LOCATION_H__

--- a/src/Locations.C
+++ b/src/Locations.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Locations.h
+++ b/src/Locations.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -7,9 +7,9 @@
 #ifndef __LOCATIONS_H__
 #define __LOCATIONS_H__
 
-#include "Location.h" 
+#include "Location.h"
 #include "DiseaseModel.h"
-#include "Location.h" 
+#include "Location.h"
 #include "contact_model/ContactModel.h"
 
 #include <vector>
@@ -30,7 +30,7 @@ class Locations : public CBase_Locations {
     void pup(PUP::er &p);
     void ReceiveVisitMessages(VisitMessage visitMsg);
     void ComputeInteractions(); // calls ReceiveInfections
-    
+
     // Load location data from CSV.
     void loadLocationData();
 

--- a/src/Main.C
+++ b/src/Main.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Main.h
+++ b/src/Main.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020 The Loimos Project Developers.
+# Copyright 2020-2023 The Loimos Project Developers.
 # See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT

--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -1,3 +1,8 @@
+# Copyright 2020-2023 The Loimos Project Developers.
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
 # Set the environment variable CHARM_HOME to the Charm++ installation with projections enabled
 CHARM_HOME ?= /usr/local/charm
 

--- a/src/Message.h
+++ b/src/Message.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/People.C
+++ b/src/People.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/People.h
+++ b/src/People.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -38,7 +38,7 @@ class People : public CBase_People {
     People();
     People(CkMigrateMessage *msg);
     void pup(PUP::er &p);
-    void SendVisitMessages(); 
+    void SendVisitMessages();
     void SyntheticSendVisitMessages();
     void RealDataSendVisitMessages();
     void ReceiveInteractions(InteractionMessage interMsg);

--- a/src/Person.C
+++ b/src/Person.C
@@ -1,4 +1,4 @@
-/* Copyright 2021 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/Person.h
+++ b/src/Person.h
@@ -1,4 +1,4 @@
-/* Copyright 2021 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -34,7 +34,7 @@ class Person : public DataInterface {
 
         // Holds visit messages for each day
         std::vector<std::vector<VisitMessage> > visitsByDay;
-        
+
         // Various dynamic attributes of the person
         std::vector<union Data> personData;
 

--- a/src/contact_model/ContactModel.C
+++ b/src/contact_model/ContactModel.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -42,7 +42,7 @@ bool ContactModel::madeContact(
 }
 
 ContactModel *createContactModel() {
-  
+
   if ((int) ContactModelType::constant_probability == contactModelType) {
     return new ContactModel();
 

--- a/src/contact_model/ContactModel.h
+++ b/src/contact_model/ContactModel.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -26,7 +26,7 @@ class ContactModel {
     std::default_random_engine *generator;
     std::uniform_real_distribution<> unitDistrib;
     int contactProbabilityIndex;
-  
+
   public:
     ContactModel();
     // Explicitly create other default constructors and assignment operators

--- a/src/contact_model/MinMaxAlphaModel.C
+++ b/src/contact_model/MinMaxAlphaModel.C
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -27,7 +27,7 @@ MinMaxAlphaModel::MinMaxAlphaModel() {
 // Compute this location's contact probability and store it as an attribute
 void MinMaxAlphaModel::computeLocationValues(Location& location) {
   std::vector<union Data> &data = location.getDataField();
-  
+
   if (-1 == contactProbabilityIndex) {
     contactProbabilityIndex = (int) data.size();
   }
@@ -52,7 +52,7 @@ bool MinMaxAlphaModel::madeContact(
   const Event& infectiousEvent,
   Location& location
 ) {
-  union Data contactProbability = 
+  union Data contactProbability =
     location.getDataField()[contactProbabilityIndex];
   return unitDistrib(*generator) < contactProbability.probability;
 }

--- a/src/contact_model/MinMaxAlphaModel.h
+++ b/src/contact_model/MinMaxAlphaModel.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -22,7 +22,7 @@ class MinMaxAlphaModel : public ContactModel {
     // Specifies where to look for the attribute we create to store each
     // location's contact probability
     int contactProbabilityIndex;
-  
+
   public:
     // We need to re-declare all of these methods from ContactModel so
     // we can override them

--- a/src/disease_model/disease.proto
+++ b/src/disease_model/disease.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 The Loimos Project Developers.
+// Copyright 2020-2023 The Loimos Project Developers.
 // See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: MIT

--- a/src/disease_model/distribution.proto
+++ b/src/disease_model/distribution.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 The Loimos Project Developers.
+// Copyright 2020-2023 The Loimos Project Developers.
 // See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: MIT

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -1,4 +1,4 @@
-// Copyright 2020 The Loimos Project Developers.
+// Copyright 2020-2023 The Loimos Project Developers.
 // See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: MIT

--- a/src/readers/DataInterface.h
+++ b/src/readers/DataInterface.h
@@ -1,4 +1,4 @@
-/* Copyright 2021 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/readers/DataReader.h
+++ b/src/readers/DataReader.h
@@ -1,4 +1,4 @@
-/* Copyright 2021 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT
@@ -18,7 +18,7 @@
 #define MAX_INPUT_lineLength (std::streamsize) 262144 // 2^18
 
 namespace DataTypes {
-    enum DataType { int_b10, uint_32, string, probability, category }; 
+    enum DataType { int_b10, uint_32, string, probability, category };
 }
 
 union Data {
@@ -35,7 +35,7 @@ PUPbytes(union Data);
  * Defines a generic data reader for any child class of DataInterface.
  * Array definition is child object dependent so this required that the
  * code be defined in the .h file rather than in the .C.
- */ 
+ */
 template <class T>
 class DataReader {
     public:
@@ -77,14 +77,14 @@ class DataReader {
                             } else {
                                 if (field->has_b10int() || field->has_foreignid()) {
                                     // TODO parse this directly.
-                                    objData[numDataFields].int_b10 = 
+                                    objData[numDataFields].int_b10 =
                                         std::stoi(std::string(start, dataLen));
                                 } else if (field->has_label()) {
-                                    objData[numDataFields].str = 
+                                    objData[numDataFields].str =
                                         new std::string(start, dataLen);
                                 } else if (field->has_bool_()) {
                                     if (dataLen == 1) {
-                                        objData[numDataFields].boolean = 
+                                        objData[numDataFields].boolean =
                                         (start[0] == 't' || start[0] == '1');
                                     } else {
                                         objData[numDataFields].boolean = false;
@@ -99,7 +99,7 @@ class DataReader {
                 }
             }
         }
-        
+
         static int getNonZeroAttributes(loimos::proto::CSVDefinition *dataFormat) {
             int count = 0;
             for (int c = 0; c < dataFormat->field_size(); c++) {
@@ -157,7 +157,7 @@ class DataReader {
                             // TODO process.
                             numDataFields++;
                         }
-                        
+
                     }
                     leftCommaLocation = c + 1;
                     attrIndex++;

--- a/src/readers/Preprocess.C
+++ b/src/readers/Preprocess.C
@@ -1,4 +1,4 @@
-/* Copyright 2021 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/readers/Preprocess.h
+++ b/src/readers/Preprocess.h
@@ -1,4 +1,4 @@
-/* Copyright 2021 The Loimos Project Developers.
+/* Copyright 2020-2023 The Loimos Project Developers.
  * See the top-level LICENSE file for details.
  *
  * SPDX-License-Identifier: MIT

--- a/src/readers/data.proto
+++ b/src/readers/data.proto
@@ -1,3 +1,9 @@
+/* Copyright 2020-2023 The Loimos Project Developers.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 syntax = "proto3";
 package loimos.proto;
 

--- a/src/readers/interventions.proto
+++ b/src/readers/interventions.proto
@@ -1,3 +1,9 @@
+/* Copyright 2020-2023 The Loimos Project Developers.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 syntax = "proto3";
 package loimos.proto;
 

--- a/src/tests/DiseaseModelTest.C
+++ b/src/tests/DiseaseModelTest.C
@@ -1,3 +1,9 @@
+/* Copyright 2020-2023 The Loimos Project Developers.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "../loimos.decl.h"
 #include "../DiseaseModel.h"
 #include "../People.h"


### PR DESCRIPTION
- Changed copyright year in `LICENSE.md` from just 2020 to the current range of development, i.e. 2020-2023
- Updated copyright notices on individual code files under `src` to match the above update
- Incidentally fixed a few whitespace errors (i.e. tabs or space present at the end of lines) present in the updated files