### PR TITLE
Updated profile interval

### DIFF
--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -16,7 +16,7 @@ mainmodule loimos {
   // CBase_* classes defined, and these constants are only used in this file)
   #define PROFILING_START_DAY 7
   #define PROFILING_END_DAY 10
-  #define PROFILING_INTERVAL 3
+  #define PROFILING_INTERVAL 1
   #define SHOULD_PROFILE(day) ((day) >= PROFILING_START_DAY &&\
     (day) <= PROFILING_END_DAY && \
     ((day) - PROFILING_START_DAY) % PROFILING_INTERVAL == 0)

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -14,15 +14,17 @@ mainmodule loimos {
 
   // Profiling/LB parameters (these are here because Defs.h depends on having
   // CBase_* classes defined, and these constants are only used in this file)
-  #define PROFILING_START_DAY DAYS_IN_WEEK
+  #define PROFILING_START_DAY 7
+  #define PROFILING_END_DAY 10
   #define PROFILING_INTERVAL 3
-  #define SHOULD_PROFILE(day) (day >= PROFILING_START_DAY &&\
-    (day - PROFILING_START_DAY) % PROFILING_INTERVAL == 0)
+  #define SHOULD_PROFILE(day) ((day) >= PROFILING_START_DAY &&\
+    (day) <= PROFILING_END_DAY && \
+    ((day) - PROFILING_START_DAY) % PROFILING_INTERVAL == 0)
 
   #define LB_START_DAY 6
-  #define LB_INTERVAL DAYS_IN_WEEK
-  #define SHOULD_LB(day) (day >= LB_START_DAY &&\
-    (day - LB_START_DAY) % LB_INTERVAL == 0)
+  #define LB_INTERVAL 7
+  #define SHOULD_LB((day)) ((day) >= LB_START_DAY &&\
+    ((day) - LB_START_DAY) % LB_INTERVAL == 0)
 
   #ifdef USE_HYPERCOMM
   include "AggregatorParam.h";
@@ -104,7 +106,7 @@ mainmodule loimos {
       for(day = 0; day < numDays; day++) {
         //serial{CkPrintf("  Starting iteration\n");}
         #ifdef ENABLE_TRACING
-          if (SHOULD_PROFILE(day)){
+          if (SHOULD_PROFILE(day) && !SHOULD_PROFILE(day - 1)){
             serial{traceArray.traceOn();}
             when traceSwitchOn() {}
           }
@@ -199,11 +201,9 @@ mainmodule loimos {
         #endif // ENABLE_LB
 
         #ifdef ENABLE_TRACING
-          if (SHOULD_PROFILE(day)) {
+          if (SHOULD_PROFILE(day) && !SHOULD_PROFILE(day + 1)) {
             serial{traceArray.traceOff();}
-            when traceSwitchOff(){
-              serial{traceArray.traceFlush();}
-            }
+            when traceSwitchOff(){}
 
             // Toggled by ENABLE_TRACING to group profiling code
             serial{traceArray.reportMemoryUsage();}
@@ -212,6 +212,10 @@ mainmodule loimos {
                 CkPrintf("Currently using %ld kb in total\n", usage);
               }
             }
+          }
+
+          if (SHOULD_PROFILE(day) {
+            serial{traceArray.traceFlush();}
           }
 
         #endif // ENABLE_TRACING


### PR DESCRIPTION
- Added end day option to profile settings
- Switched default profiling interval (so that consecutive iterations are profiled)
- Only call `traceArray.traceSwitchOn()` and `traceArray.traceSwitchOff()` when the previous and next iterations, respectively, won't be profiled but the current one would. This stops us from unnecessarily calling `traceSwitchOff` at the end of one iteration just to call `traceSwitchOn` at the start of the next.