### PR TITLE
Synthetic Graph Bugfix

### DIFF
--- a/scripts/synthetic_graphs/translation_strategies.py
+++ b/scripts/synthetic_graphs/translation_strategies.py
@@ -88,7 +88,7 @@ def assign_num_occupants(num_locations, num_people):
         # np.where returns a tuple wrapping the answer sometimes, which causes
         # np.random.choice to think it's dealing with a 2D array
         tmp = np.where(occupant_counts != 0)
-        if hasattr(tmp, '__iter__'):
+        if hasattr(tmp, "__iter__"):
             tmp = tmp[0]
 
         to_subtract = np.random.choice(tmp, size=num_extra)

--- a/scripts/synthetic_graphs/translation_strategies.py
+++ b/scripts/synthetic_graphs/translation_strategies.py
@@ -62,7 +62,7 @@ def assign_num_occupants(num_locations, num_people):
     mean_people = num_locations / num_people
     print(
         f"Assigning {num_people} people to {num_locations} locs "
-        + "(about {mean_people}/loc)"
+        + f"(about {mean_people}/loc)"
     )
     occupant_counts = np.random.poisson(lam=mean_people, size=num_locations)
     # No point in simulating empty locations
@@ -76,15 +76,24 @@ def assign_num_occupants(num_locations, num_people):
     # Note that if we sample duplicate indices, they won't be incremented
     # multiple times, so we may need to repeat this process a couple times
     while num_generated_people < num_people:
-        to_add = np.random.random_integers(
-            0, num_locations - 1, size=num_people - num_generated_people
-        )
+        num_missing = num_people - num_generated_people
+        print(f"  Attempting to add {num_missing} missing people")
+        to_add = np.random.random_integers(0, num_locations - 1, size=num_missing,)
         occupant_counts[to_add] += 1
         num_generated_people = np.sum(occupant_counts)
     while num_generated_people > num_people:
-        to_subtract = np.random.choice(
-            np.where(occupant_counts != 0), size=num_generated_people - num_people
-        )
+        num_extra = num_generated_people - num_people
+        print(f"  Attempting to remove {num_extra} extra people")
+
+        # np.where returns a tuple wrapping the answer sometimes, which causes
+        # np.random.choice to think it's dealing with a 2D array
+        tmp = np.where(occupant_counts != 0)
+        try:
+            tmp = tmp[0]
+        except:
+            pass
+
+        to_subtract = np.random.choice(tmp, size=num_extra)
         occupant_counts[to_subtract] -= 1
         num_generated_people = np.sum(occupant_counts)
 

--- a/scripts/synthetic_graphs/translation_strategies.py
+++ b/scripts/synthetic_graphs/translation_strategies.py
@@ -88,10 +88,8 @@ def assign_num_occupants(num_locations, num_people):
         # np.where returns a tuple wrapping the answer sometimes, which causes
         # np.random.choice to think it's dealing with a 2D array
         tmp = np.where(occupant_counts != 0)
-        try:
+        if hasattr(tmp, '__iter__'):
             tmp = tmp[0]
-        except:
-            pass
 
         to_subtract = np.random.choice(tmp, size=num_extra)
         occupant_counts[to_subtract] -= 1

--- a/scripts/synthetic_graphs/translation_strategies.py
+++ b/scripts/synthetic_graphs/translation_strategies.py
@@ -78,7 +78,7 @@ def assign_num_occupants(num_locations, num_people):
     while num_generated_people < num_people:
         num_missing = num_people - num_generated_people
         print(f"  Attempting to add {num_missing} missing people")
-        to_add = np.random.random_integers(0, num_locations - 1, size=num_missing,)
+        to_add = np.random.random_integers(0, num_locations - 1, size=num_missing)
         occupant_counts[to_add] += 1
         num_generated_people = np.sum(occupant_counts)
     while num_generated_people > num_people:


### PR DESCRIPTION
Fixed error in translation_strategies.py where np.where would return a tuple wrapping an np.array instead of the array by itself, causing np.random.choice to treat the resulting index array as 2D