### PR TITLE
Parse distinct visit data from textproto files

### DIFF
--- a/data/populations/synthetic_small_city/visits.textproto
+++ b/data/populations/synthetic_small_city/visits.textproto
@@ -1,3 +1,13 @@
+<<<<<<< Updated upstream
+=======
+num_rows: 3241
+start_time: {
+    days: 0
+}
+duration: {
+    days: 7
+}
+>>>>>>> Stashed changes
 fields {
     field_name: "daynum"
     ignore: {}

--- a/data/populations/utopia/visits.textproto
+++ b/data/populations/utopia/visits.textproto
@@ -1,3 +1,13 @@
+<<<<<<< Updated upstream
+=======
+num_rows: 64
+start_time: {
+    days: 0
+}
+duration: {
+    days: 1
+}
+>>>>>>> Stashed changes
 fields {
     field_name: "hid"
     ignore: {}

--- a/scripts/preprocessing/create_textproto.py
+++ b/scripts/preprocessing/create_textproto.py
@@ -73,10 +73,10 @@ def parse_args():
         + "population dir",
     )
     parser.add_argument(
-        "-m",
-        "--visits-metadata",
+        "-b",
+        "--basic-metadata",
         action="store_true",
-        help="Set this flag to compute detailed metadata for visits",
+        help="Set this flag to avoid computing detailed metadata for visits",
     )
     parser.add_argument(
         "-P",
@@ -173,9 +173,9 @@ def create_textproto(
 def main():
     args = parse_args()
 
-    visits_metadata_type = "basic"
-    if args.visits_metadata:
-        visits_metadata_type = "visits"
+    visits_metadata_type = "visits"
+    if args.basic_metadata:
+        visits_metadata_type = "basic"
 
     create_textproto(
         args.pop_dir, args.people_file, PEOPLE_TYPES, print_only=args.print_only

--- a/scripts/preprocessing/partition.py
+++ b/scripts/preprocessing/partition.py
@@ -355,7 +355,9 @@ def main(args):
         if not args.offsets_only:
             update_visits(args, lid_update)
             if "people" not in args.to_partition:
-                create_textproto(args.out_dir, args.visits_file, VISITS_TYPES)
+                create_textproto(
+                    args.out_dir, args.visits_file, VISITS_TYPES, metadata_type="visits"
+                )
         create_textproto(
             args.out_dir,
             args.locations_file,
@@ -369,7 +371,9 @@ def main(args):
         offsets, pid_update = partition_people(args)
         if not args.offsets_only:
             update_visits(args, pid_update, id_col="pid")
-            create_textproto(args.out_dir, args.visits_file, VISITS_TYPES)
+            create_textproto(
+                args.out_dir, args.visits_file, VISITS_TYPES, metadata_type="visits"
+            )
         create_textproto(
             args.out_dir, args.people_file, PEOPLE_TYPES, partition_offsets=offsets
         )


### PR DESCRIPTION
- Made generating detailed visits metadata the default in `create_textproto.py`
- Switched `partition.py` to automatically generating this data as well
- Added detailed visit metadata to example datasets in repo