### PR TITLE
Visit counting

### DIFF
--- a/src/Locations.cpp
+++ b/src/Locations.cpp
@@ -224,7 +224,6 @@ void Locations::ComputeInteractions() {
   CkCallback cb(CkReductionTarget(Main, ReceiveInteractionsCount), mainProxy);
   contribute(sizeof(Counter), &numInteractions,
       CONCAT(CkReduction::sum_, COUNTER_REDUCTION_TYPE), cb);
-
 #endif
 
 #if ENABLE_DEBUG >= DEBUG_PER_CHARE

--- a/src/People.cpp
+++ b/src/People.cpp
@@ -444,7 +444,7 @@ void People::pup(PUP::er &p) {
 
 void People::SendVisitMessages() {
   // Send activities for each person.
-#if ENABLE_DEBUG >= DEBUG_PER_CHARE
+#if ENABLE_DEBUG >= DEBUG_VERBOSE
   Id minId = numPeople;
   Id maxId = 0;
   totalVisitsForDay = 0;
@@ -493,6 +493,11 @@ void People::SendVisitMessages() {
     }
   }
 
+#if ENABLE_DEBUG >= DEBUG_VERBOSE
+  CkCallback cb(CkReductionTarget(Main, ReceiveVisitsSentCount), mainProxy);
+  contribute(sizeof(Counter), &totalVisitsForDay,
+      CONCAT(CkReduction::sum_, COUNTER_REDUCTION_TYPE), cb);
+#endif
 #if ENABLE_DEBUG >= DEBUG_PER_CHARE
   if (0 == day) {
     CkPrintf("    Chare %d (P %d, T %d): %d visits, %lu people (in [%d, %d])\n",


### PR DESCRIPTION
- Now counting total visits sent with DEBUG_VERBOSE or higher set. This is helpful for on the fly runs, where the visit count is not known _a priori_.