### PR TITLE
Sort Visit Data to Match People Data After Partitioning

### DIFF
--- a/scripts/preprocessing/partition.py
+++ b/scripts/preprocessing/partition.py
@@ -347,7 +347,6 @@ def update_visits(args, id_update, id_col="lid", sort_values=True):
             print("Saving visits", flush=True)
             write_csv(args.out_dir, args.visits_file, visits)
 
-
     else:
         visits = read_csv(args.in_dir, args.visits_file, args.num_visits)
 

--- a/scripts/preprocessing/partition.py
+++ b/scripts/preprocessing/partition.py
@@ -218,6 +218,7 @@ def linear_cut_partition(
     df[partition_col] = (
         np.ceil(df[load_col].cumsum() / mean_load_per_partition) - 1
     ).astype(int)
+    df.loc[df[partition_col] < 0, partition_col] = 0
 
     df.at[df.shape[0] - 1, partition_col] = num_partitions - 1
 

--- a/scripts/preprocessing/partition.py
+++ b/scripts/preprocessing/partition.py
@@ -6,7 +6,7 @@ import shutil
 
 import pandas as pd
 import numpy as np
-from preprocess import read_csv, write_csv, make_contiguous, update_ids
+from preprocess import read_csv, write_csv, make_contiguous, update_ids, VISIT_SORT_COLS
 from create_textproto import (
     create_textproto,
     PEOPLE_TYPES,
@@ -321,26 +321,40 @@ def update_chunk(args, visits_chunk, id_update, id_col="lid"):
     return visits_chunk
 
 
-def update_visits(args, id_update, id_col="lid"):
+def update_visits(args, id_update, id_col="lid", sort_values=True):
     if isinstance(id_update, int) and 0 == id_update:
         return
     if args.num_visits is not None:
         visit_chunks = read_csv(
             args.in_dir, args.visits_file, iterator=True, chunksize=args.num_visits
         )
+        chunk_dfs = []
         for i, chunk in enumerate(visit_chunks):
             print(f"Updating {id_col}s in chunk {i}")
             chunk = update_chunk(args, chunk, id_update, id_col=id_col)
-            if i == 0:
+            if sort_values:
+                chunk_dfs.append(chunk)
+            elif i == 0:
                 write_csv(args.out_dir, args.visits_file, chunk)
             else:
                 write_csv(args.out_dir, args.visits_file, chunk, mode="a", header=False)
+        if sort_values:
+            visits = pd.concat(chunk_dfs)
+            print("Sorting visits")
+            visits.sort_values(VISIT_SORT_COLS, inplace=True)
+
+            print("Saving visits", flush=True)
+            write_csv(args.out_dir, args.visits_file, visits)
+
 
     else:
         visits = read_csv(args.in_dir, args.visits_file, args.num_visits)
 
         print(f"Updating visits {id_col}s", flush=True)
         visits = update_chunk(args, visits, id_update, id_col=id_col)
+        if sort_values:
+            print("Sorting visits")
+            visits.sort_values(VISIT_SORT_COLS, inplace=True)
 
         print("Saving visits", flush=True)
         write_csv(args.out_dir, args.visits_file, visits)
@@ -353,7 +367,7 @@ def main(args):
     if "locations" in args.to_partition:
         offsets, lid_update = partition_locations(args)
         if not args.offsets_only:
-            update_visits(args, lid_update)
+            update_visits(args, lid_update, sort_values=False)
             if "people" not in args.to_partition:
                 create_textproto(
                     args.out_dir, args.visits_file, VISITS_TYPES, metadata_type="visits"

--- a/src/Partitioner.cpp
+++ b/src/Partitioner.cpp
@@ -6,6 +6,7 @@
 
 #include "charm++.h"
 #include "Partitioner.h"
+#include "Defs.h"
 #include "Types.h"
 #include "protobuf/data.pb.h"
 #include "readers/Preprocess.h"

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 mainmodule loimos {
+  include "Defs.h";
   include "Types.h";
   include "Interaction.h";
   include "Message.h";
@@ -193,15 +194,13 @@ mainmodule loimos {
       serial {
         CkPrintf("Finished simulating %d days in %lf seconds.\n",
           day, (CkWallTimer() - profile.simulationStartTime));
-#ifdef ENABLE_DEBUG
-        if (ENABLE_DEBUG >= DEBUG_VERBOSE) {
-          CkPrintf("  Processed " COUNTER_PRINT_TYPE " visits, "
-            COUNTER_PRINT_TYPE " interactions, and "
-            COUNTER_PRINT_TYPE " exposures, "
-            COUNTER_PRINT_TYPE " total exposure duration\n",
-            profile.totalVisits, profile.totalInteractions,
-            profile.totalExposures, profile.totalExposureDuration);
-        }
+#if ENABLE_DEBUG >= DEBUG_VERBOSE
+        CkPrintf("  Processed " COUNTER_PRINT_TYPE " visits, "
+          COUNTER_PRINT_TYPE " interactions, and "
+          COUNTER_PRINT_TYPE " exposures, "
+          COUNTER_PRINT_TYPE " total exposure duration\n",
+          profile.totalVisits, profile.totalInteractions,
+          profile.totalExposures, profile.totalExposureDuration);
 #endif
         CkPrintf("  Visit messages took %lf seconds\n",
           profile.visitsTime);


### PR DESCRIPTION
- Updates partitioning script to re-sort visit data according to their new pids after sorting people for the ZIP code partitioning scheme
- Places initial locations without visits into partition 0 rather than partition -1