### PR TITLE
Detailed Output Bugfixes

### DIFF
--- a/.github/workflows/test-runs.yml
+++ b/.github/workflows/test-runs.yml
@@ -117,15 +117,18 @@ jobs:
           export PATH=$CHARM_HOME/bin:$PATH_PROTOBUF
           export ENABLE_FORCE_FULL_RUN=1
           cd src
+          make clean
           # Make detailed output version of Loimos
           OUTPUT_FLAGS=7 make
           mv loimos loimos-out
           ./charmrun +p4 ./loimos-out 0 2 2 30 7 \
-            ci-test-out \
+            ci_test_out \
             ../data/disease_models/covid19_onepath.textproto \
+            ../data/populations/synthetic_small_city \
             +setcpuaffinity ++local
-          ls ci-test-out
-          cd ci-test-out
+          ls
+          ls ci_test_out
+          cd ci_test_out
           ls {exposures,interactions,transitions}_chare_{0,1}.csv summary.csv
 
       - name: Build and Test Non-SMP Version

--- a/.github/workflows/test-runs.yml
+++ b/.github/workflows/test-runs.yml
@@ -105,6 +105,28 @@ jobs:
             ci-test-non-smp.csv \
             ../data/disease_models/covid19_onepath.textproto \
             +setcpuaffinity ++local
+      
+      - name: Build and Test Detailed Outputs
+        id: test-out-loimos
+        run: |
+          export PROTOBUF_HOME=$GITHUB_WORKSPACE/protobuf/install
+          export GTEST_HOME=$GITHUB_WORKSPACE/googletest/install/cmake
+          export LD_LIBRARY_PATH=$PROTOBUF_HOME/lib:$LD_LIBRARY_PATH
+          export PATH_PROTOBUF=$PROTOBUF_HOME/bin:$PATH
+          export CHARM_HOME=$GITHUB_WORKSPACE/charm/netlrts-linux-x86_64
+          export PATH=$CHARM_HOME/bin:$PATH_PROTOBUF
+          export ENABLE_FORCE_FULL_RUN=1
+          cd src
+          # Make detailed output version of Loimos
+          OUTPUT_FLAGS=7 make
+          mv loimos loimos-out
+          ./charmrun +p4 ./loimos-out 0 2 2 30 7 \
+            ci-test-out \
+            ../data/disease_models/covid19_onepath.textproto \
+            +setcpuaffinity ++local
+          ls ci-test-out
+          cd ci-test-out
+          ls {exposures,interactions,transitions}_chare_{0,1}.csv summary.csv
 
       - name: Build and Test Non-SMP Version
         id: test-non-smp

--- a/src/Locations.cpp
+++ b/src/Locations.cpp
@@ -284,12 +284,6 @@ Counter Locations::processEvents(Location *loc) {
       // Remove the arrival event corresponding to this departure
       std::pop_heap(arrivals->begin(), arrivals->end(), Event::greaterPartner);
       arrivals->pop_back();
-// #if ENABLE_DEBUG >= DEBUG_VERBOSE
-//       duration += saveInteractions(*loc, event, interactionsFile);
-// #endif
-#if OUTPUT_FLAGS & OUTPUT_OVERLAPS
-      saveInteractions(*loc, event, interactionsFile);
-#endif
 
 #if OUTPUT_FLAGS & OUTPUT_OVERLAPS
       saveInteractions(*loc, event, interactionsFile);

--- a/src/Locations.h
+++ b/src/Locations.h
@@ -62,10 +62,10 @@ class Locations : public CBase_Locations {
   // specified person to the appropriate People chare
   inline void sendInteractions(Location *loc, Id personIdx);
 
-  #if ENABLE_DEBUG >= DEBUG_VERBOSE
+#if OUTPUT_FLAGS & OUTPUT_OVERLAPS
   Counter saveInteractions(const Location &loc, const Event &departure,
     std::ofstream *out);
-  #endif
+#endif
 
  public:
   explicit Locations(int seed, std::string scenarioPath);

--- a/src/People.cpp
+++ b/src/People.cpp
@@ -681,10 +681,10 @@ void People::UpdateDiseaseState(Person *person) {
 #if OUTPUT_FLAGS & OUTPUT_TRANSITIONS
     // State transition information for initial infections is reported when
     // they're infected
-    if (!scenario->isSusceptible(person->state)) {
+    if (!scenario->diseaseModel->isSusceptible(person->state)) {
       // tick,pid,exit_state,contact_pid,contact_start
       *transitionsFile << day << "," << person->getUniqueId() << ","
-          << scenario->getStateLabel(person->next_state)
+          << scenario->diseaseModel->getStateLabel(person->next_state)
           << ",-1,-1" << std::endl;
     }
 #endif

--- a/src/readers/Parse.cpp
+++ b/src/readers/Parse.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Parse.h"
+#include "Preprocess.h"
 #include "../Types.h"
 #include "../contact_model/ContactModel.h"
 #include "charm++.h"
@@ -106,7 +107,7 @@ void parse(int argc, char **argv, Arguments *args) {
   if (args->outputPath.back() == '/') {
     args->outputPath.pop_back();
   }
-  create_directory(args->outputPath, args->isOnTheFlyRun ? "." : args->scenarioPath);
+  createDirectory(args->outputPath, args->isOnTheFlyRun ? "." : args->scenarioPath);
   args->outputPath.push_back('/');
 #endif
 


### PR DESCRIPTION
Fixes a few minor issues with the detailed output option introduced by the global data rework
- Switched from using `scenario->` to `scenario->diseaseModel->` for a few calls to DiseaseModel methods
- Removed duplicate call to `saveInteractions`
- Switched to having the declaration of `saveInteractions` conditioned on `OUTPUT_FLAGS` rather than `ENABLE_DEBUG`
- Added a test build/run with detailed output to the CI tests