### PR TITLE
Inline Entry Methods

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,6 +33,9 @@ endif
 ifdef ENABLE_AGGREGATION
 BIN   :=$(BIN)-agg
 endif
+ifdef ENABLE_INLINE
+BIN   :=$(BIN)-in
+endif
 ifdef ENABLE_SC
 BIN   :=$(BIN)-sc
 endif

--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -83,6 +83,10 @@ ifdef ENABLE_AGGREGATION
 OPTS     += -DENABLE_AGGREGATION
 endif
 
+ifdef ENABLE_INLINE
+OPTS     += -DENABLE_INLINE
+endif
+
 ifdef ENABLE_SC
 OPTS     += -DENABLE_SC
 endif

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -14,8 +14,10 @@ mainmodule loimos {
   include "AggregatorParam.h";
 #endif // USE_HYPERCOMM
 
-#ifdef ENABLE_AGGREGATION
+#if defined(ENABLE_AGGREGATION)
   #define AGGREGATE [aggregate(numDimensions: 1)]
+#elseif defined(ENABLE_INLINE)
+  #define AGGREGATE [inline]
 #else
   #define AGGREGATE
 #endif


### PR DESCRIPTION
- Added option to make major/expensive entry methods use the Charm++ `inline` attribute, which causes entry method calls on the same PE to be performed using regular C++ function calls. Note this seems to be mutually exclusive with message aggregation