### PR TITLE
Transmissibility Commandline Override

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Where
 For pre-defined populations, run Loimos with the command:
 
 ```bash
-./loimos 0 <NPP> <NLP> <ND> <NDV> <OF> <DF> <SD> [-m] [-i <IF>] [-s [<S>]] [-or <OR>]
+./loimos 0 <NPP> <NLP> <ND> <NDV> <OF> <DF> <SD> [-m] [-i <IF>] [-s [<S>]] [-or <OR>] [-t [<T>]]
 ```
 
 Where
@@ -133,6 +133,10 @@ Where
 - `-or` or `--offset-ratio` is an optional flag specifying to look for an
   offset file containing `OR` times the number of person and location chares
   entries before using the offsets saved to `SD/{people,locations}.textproto`.
+- `-t` or `--transmissibility` is an optional flag which overrides the
+  transmissibility value in the provided disease model (given in `DF`),
+  and takes a floating point value of 0.0 or greater (this flag will be
+  ignored if `T` is negative)
 
 ## Authors
 

--- a/src/DiseaseModel.cpp
+++ b/src/DiseaseModel.cpp
@@ -52,10 +52,14 @@
  * Constructor which loads in disease file from text proto file.
  * On failure, aborts the entire simulation.
  */
-DiseaseModel::DiseaseModel(std::string diseasePath, const AttributeTable &attrs) {
+DiseaseModel::DiseaseModel(std::string diseasePath, double transmissibility,
+    const AttributeTable &attrs) {
   model = new loimos::proto::DiseaseModel();
   readProtobuf(diseasePath, model);
   assert(model->disease_states_size() != 0);
+  if (transmissibility >= 0.0) {
+    model->set_transmissibility(transmissibility);
+  }
 
   ageIndex = attrs.getAttributeIndex("age");
   susceptibilityIndex = attrs.getAttributeIndex("susceptibility");

--- a/src/DiseaseModel.h
+++ b/src/DiseaseModel.h
@@ -43,7 +43,8 @@ class DiseaseModel {
   int susceptibilityIndex;
   int infectivityIndex;
 
-  DiseaseModel(std::string diseasePath, const AttributeTable &attrs);
+  DiseaseModel(std::string diseasePath, double transmissibility,
+    const AttributeTable &attrs);
   DiseaseState getIndexOfState(std::string stateLabel) const;
   std::tuple<DiseaseState, Time> transitionFromState(DiseaseState fromState,
     std::default_random_engine *generator) const;

--- a/src/Scenario.cpp
+++ b/src/Scenario.cpp
@@ -104,7 +104,8 @@ Scenario::Scenario(Arguments args) : seed(args.seed), numDays(args.numDays),
       numLocations, args.numLocationPartitions);
   }
 
-  diseaseModel = new DiseaseModel(args.diseasePath, personAttributes);
+  diseaseModel = new DiseaseModel(args.diseasePath, args.transmissibility,
+    personAttributes);
   if (args.hasIntervention) {
     interventionModel = new InterventionModel(args.interventionPath,
       &personAttributes, &locationAttributes, *diseaseModel);

--- a/src/readers/Parse.cpp
+++ b/src/readers/Parse.cpp
@@ -142,6 +142,9 @@ void parse(int argc, char **argv, Arguments *args) {
     } else if (("-or" == tmp || "--offset-ratio" == tmp)
         && argNum + 1 < argc) {
       args->partitionsToOffsetsRatio = atol(argv[++argNum]);
+    } else if (("-t" == tmp || "--transmissibility" == tmp)
+        && argNum + 1 < argc) {
+      args->transmissibility = atof(argv[++argNum]);
     }
   }
 

--- a/src/readers/Parse.cpp
+++ b/src/readers/Parse.cpp
@@ -119,6 +119,7 @@ void parse(int argc, char **argv, Arguments *args) {
   // Optional arguments
   args->contactModelType = static_cast<int>(ContactModelType::constant_probability);
   args->hasIntervention = false;
+  args->transmissibility = -1.0;
   for (; argNum < argc; ++argNum) {
     std::string tmp = std::string(argv[argNum]);
 

--- a/src/readers/Parse.h
+++ b/src/readers/Parse.h
@@ -31,6 +31,7 @@ struct Arguments {
   Time numDays;
   Time numDaysWithDistinctVisits;
   Time numDaysToSeedOutbreak;
+  double transmissibility;
   int seed;
 
   bool hasIntervention;
@@ -55,6 +56,7 @@ struct Arguments {
     p | numDaysToSeedOutbreak;
     p | numInitialInfectionsPerDay;
     p | partitionsToOffsetsRatio;
+    p | transmissibility;
     p | seed;
     p | hasIntervention;
     p | contactModelType;


### PR DESCRIPTION
- Adds a new commandline argument (`-t` or `--transmissibility`) which overrides the transmissibility value given in the disease model file