### PR TITLE
Updated interventions account for visit data being stored on location chares

### DIFF
--- a/src/DiseaseModel.cpp
+++ b/src/DiseaseModel.cpp
@@ -252,12 +252,12 @@ DiseaseState DiseaseModel::getHealthyState(const std::vector<Data> &dataField) c
 
 /** Returns if someone is infectious */
 bool DiseaseModel::isInfectious(DiseaseState personState) const {
-  return model->disease_states(personState).infectivity() != 0.0;
+  return model->disease_states(personState).infectivity() > 0.0;
 }
 
 /** Returns if someone is susceptible */
 bool DiseaseModel::isSusceptible(DiseaseState personState) const {
-  return model->disease_states(personState).susceptibility() != 0.0;
+  return model->disease_states(personState).susceptibility() > 0.0;
 }
 
 /** Returns the name of the person's state, as a C-style string */

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -57,21 +57,21 @@ void Location::addEvent(const Event &e) {
   events.push_back(e);
 }
 
-void Location::filterVisits(const void *cause, VisitTest keepVisit) {
+void Location::filterVisits(InterventionId interventionId, VisitTest keepVisit) {
   for (std::vector<VisitMessage> &visits : visitsByDay) {
     for (int i = 0; i < visits.size(); ++i) {
       if (!keepVisit(visits[i])) {
-        visits[i].deactivatedBy = cause;
+        visits[i].deactivatedBy = interventionId;
       }
     }
   }
 }
 
-void Location::restoreVisits(const void *cause, VisitTest restoreVisit) {
+void Location::restoreVisits(InterventionId interventionId, VisitTest restoreVisit) {
   for (std::vector<VisitMessage> &visits : visitsByDay) {
     for (int i = 0; i < visits.size(); ++i) {
-      if (cause == visits[i].deactivatedBy && restoreVisit(visits[i])) {
-        visits[i].deactivatedBy = NULL;
+      if (interventionId == visits[i].deactivatedBy && restoreVisit(visits[i])) {
+        visits[i].deactivatedBy = DEACTIVATED_BY_NONE;
       }
     }
   }

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -58,11 +58,23 @@ void Location::addEvent(const Event &e) {
 }
 
 void Location::filterVisits(const void *cause, VisitTest keepVisit) {
-  visitFilters[cause] = keepVisit;
+  for (std::vector<VisitMessage> &visits : visitsByDay) {
+    for (int i = 0; i < visits.size(); ++i) {
+      if (!keepVisit(visits[i])) {
+        visits[i].deactivatedBy = cause;
+      }
+    }
+  }
 }
 
 void Location::restoreVisits(const void *cause) {
-  visitFilters.erase(cause);
+  for (std::vector<VisitMessage> &visits : visitsByDay) {
+    for (int i = 0; i < visits.size(); ++i) {
+      if (cause == visits[i].deactivatedBy) {
+        visits[i].deactivatedBy = NULL;
+      }
+    }
+  }
 }
 
 bool Location::acceptsVisit(const VisitMessage &visit) {

--- a/src/Location.cpp
+++ b/src/Location.cpp
@@ -67,10 +67,10 @@ void Location::filterVisits(const void *cause, VisitTest keepVisit) {
   }
 }
 
-void Location::restoreVisits(const void *cause) {
+void Location::restoreVisits(const void *cause, VisitTest restoreVisit) {
   for (std::vector<VisitMessage> &visits : visitsByDay) {
     for (int i = 0; i < visits.size(); ++i) {
-      if (cause == visits[i].deactivatedBy) {
+      if (cause == visits[i].deactivatedBy && restoreVisit(visits[i])) {
         visits[i].deactivatedBy = NULL;
       }
     }

--- a/src/Location.h
+++ b/src/Location.h
@@ -67,8 +67,8 @@ class Location : public DataInterface {
   // Adds an event representing a person either arriving or departing
   // from this location
   void addEvent(const Event &e);
-  void filterVisits(const void *cause, VisitTest keepVisit) override;
-  void restoreVisits(const void *cause, VisitTest restoreVisit) override;
+  void filterVisits(InterventionId interventionId, VisitTest keepVisit) override;
+  void restoreVisits(InterventionId interventionId, VisitTest restoreVisit) override;
   bool acceptsVisit(const VisitMessage &visit);
 };
 

--- a/src/Location.h
+++ b/src/Location.h
@@ -68,7 +68,7 @@ class Location : public DataInterface {
   // from this location
   void addEvent(const Event &e);
   void filterVisits(const void *cause, VisitTest keepVisit) override;
-  void restoreVisits(const void *cause) override;
+  void restoreVisits(const void *cause, VisitTest restoreVisit) override;
   bool acceptsVisit(const VisitMessage &visit);
 };
 

--- a/src/Locations.cpp
+++ b/src/Locations.cpp
@@ -639,7 +639,16 @@ inline void Locations::sendInteractions(Location *loc,
 
 void Locations::ReceiveIntervention(PartitionId interventionIdx) {
   InterventionModel *interventions = scenario->interventionModel;
-  interventions->applyIntervention(interventionIdx, &locations);
+  std::unordered_set<Id> applied;
+  std::unordered_set<Id> removed;
+  interventions->applyIntervention(interventionIdx, &locations, &applied, &removed);
+}
+  
+void Locations::ReceiveVisitIntervention(VisitInterventionMessage msg) {
+  InterventionModel *interventions = scenario->interventionModel;
+  const Intervention<Person> &inter =
+    interventions->getPersonIntervention(msg.interventionIdx);
+  inter.apply(&locations, msg.affectedPeople, msg.previouslyAffectedPeople);
 }
 
 #ifdef ENABLE_LB

--- a/src/Locations.cpp
+++ b/src/Locations.cpp
@@ -305,8 +305,11 @@ void Locations::QueueVisits() {
   for (Location &location : locations) {
     const std::vector<VisitMessage> &visits =
       location.visitsByDay[day % scenario->numDaysWithDistinctVisits];
-
     for (const VisitMessage &visit : visits) {
+      if (!visit.isActive()) {
+        continue;
+      }
+
       const PersonState &state = visitorStates[visit.personIdx];
       Event arrival { ARRIVAL, visit.personIdx, state.state,
         state.transmissionModifier, visit.visitStart };
@@ -642,6 +645,7 @@ void Locations::ReceiveIntervention(PartitionId interventionIdx) {
   InterventionModel *interventions = scenario->interventionModel;
   std::unordered_set<Id> applied;
   std::unordered_set<Id> removed;
+  //CkPrintf("    Location chare %d: applying intervention %d\n", thisIndex, interventionIdx);
   interventions->applyIntervention(interventionIdx, &locations, &applied, &removed);
 }
 

--- a/src/Locations.cpp
+++ b/src/Locations.cpp
@@ -645,7 +645,6 @@ void Locations::ReceiveIntervention(PartitionId interventionIdx) {
   InterventionModel *interventions = scenario->interventionModel;
   std::unordered_set<Id> applied;
   std::unordered_set<Id> removed;
-  //CkPrintf("    Location chare %d: applying intervention %d\n", thisIndex, interventionIdx);
   interventions->applyIntervention(interventionIdx, &locations, &applied, &removed);
 }
 

--- a/src/Locations.cpp
+++ b/src/Locations.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <unordered_set>
 
 std::uniform_real_distribution<> Locations::unitDistrib(0.0, 1.0);
 
@@ -643,7 +644,7 @@ void Locations::ReceiveIntervention(PartitionId interventionIdx) {
   std::unordered_set<Id> removed;
   interventions->applyIntervention(interventionIdx, &locations, &applied, &removed);
 }
-  
+
 void Locations::ReceiveVisitIntervention(VisitInterventionMessage msg) {
   InterventionModel *interventions = scenario->interventionModel;
   const Intervention<Person> &inter =

--- a/src/Locations.cpp
+++ b/src/Locations.cpp
@@ -351,7 +351,7 @@ void Locations::ReceiveVisitMessages(VisitMessage visitMsg) {
 #endif
 
   // Interventions might cause us to reject some visits
-  if (!locations[localLocIdx].acceptsVisit(visitMsg)) {
+  if (!visitMsg.isActive()) {
     return;
   }
 
@@ -639,14 +639,7 @@ inline void Locations::sendInteractions(Location *loc,
 
 void Locations::ReceiveIntervention(PartitionId interventionIdx) {
   InterventionModel *interventions = scenario->interventionModel;
-  const Intervention<Location> &inter =
-    interventions->getLocationIntervention(interventionIdx);
-  for (Location &location : locations) {
-    if (location.willComply(interventionIdx)
-        && inter.test(location, location.getGenerator())) {
-      inter.apply(&location);
-    }
-  }
+  interventions->applyIntervention(interventionIdx, &locations);
 }
 
 #ifdef ENABLE_LB

--- a/src/Locations.h
+++ b/src/Locations.h
@@ -82,6 +82,7 @@ class Locations : public CBase_Locations {
   void ReceiveVisitMessages(VisitMessage visitMsg);
   void ComputeInteractions();  // calls ReceiveInfections
   void ReceiveIntervention(PartitionId interventionIdx);
+  //void ReceiveVisitIntervention(VisitInterventionMessage msg);
   #ifdef ENABLE_LB
   void ResumeFromSync();
   #endif  // ENABLE_LB

--- a/src/Locations.h
+++ b/src/Locations.h
@@ -82,7 +82,7 @@ class Locations : public CBase_Locations {
   void ReceiveVisitMessages(VisitMessage visitMsg);
   void ComputeInteractions();  // calls ReceiveInfections
   void ReceiveIntervention(PartitionId interventionIdx);
-  //void ReceiveVisitIntervention(VisitInterventionMessage msg);
+  void ReceiveVisitIntervention(VisitInterventionMessage msg);
   #ifdef ENABLE_LB
   void ResumeFromSync();
   #endif  // ENABLE_LB

--- a/src/Message.h
+++ b/src/Message.h
@@ -99,7 +99,7 @@ struct PersonState {
   PersonState() {}
   explicit PersonState(CkMigrateMessage *msg) {}
   PersonState(Id uniqueId_, DiseaseState state_,
-  double transmissionModifier_)
+    double transmissionModifier_)
     : uniqueId(uniqueId_), state(state_),
     transmissionModifier(transmissionModifier_) {}
 };
@@ -117,6 +117,26 @@ struct PersonStatesMessage {
   void pup(PUP::er& p) {  // NOLINT(runtime/references)
     p | sourcePartition;
     p | states;
+  }
+};
+
+struct VisitInterventionMessage {
+  PartitionId interventionIdx;
+  std::unordered_set<Id> affectedPeople;
+  std::unordered_set<Id> previouslyAffectedPeople;
+
+  VisitInterventionMessage() {}
+  VisitInterventionMessage(PartitionId interventionIdx_,
+      const std::unordered_set<Id>& affectedPeople_,
+      const std::unordered_set<Id>& previouslyAffectedPeople_)
+    : interventionIdx(interventionIdx_),
+    affectedPeople(affectedPeople_),
+    previouslyAffectedPeople(previouslyAffectedPeople_) {}
+  
+  void pup(PUP::er& p) {  // NOLINT(runtime/references) 
+    p | interventionIdx;
+    p | affectedPeople;
+    p | previouslyAffectedPeople;
   }
 };
 

--- a/src/Message.h
+++ b/src/Message.h
@@ -132,8 +132,8 @@ struct VisitInterventionMessage {
     : interventionIdx(interventionIdx_),
     affectedPeople(affectedPeople_),
     previouslyAffectedPeople(previouslyAffectedPeople_) {}
-  
-  void pup(PUP::er& p) {  // NOLINT(runtime/references) 
+
+  void pup(PUP::er& p) {  // NOLINT(runtime/references)
     p | interventionIdx;
     p | affectedPeople;
     p | previouslyAffectedPeople;

--- a/src/Message.h
+++ b/src/Message.h
@@ -14,7 +14,9 @@
 #include <vector>
 #include <unordered_set>
 #include <functional>
+#include <limits>
 
+const InterventionId DEACTIVATED_BY_NONE = -1;
 struct VisitMessage {
   Id locationIdx;
   Id personIdx;
@@ -23,19 +25,19 @@ struct VisitMessage {
   Time visitEnd;
   // Susceptibility or infectivity, depending on disease state
   double transmissionModifier;
-  const void *deactivatedBy;
+  int deactivatedBy;
 
   VisitMessage() {}
-  explicit VisitMessage(CkMigrateMessage *msg) {}
+  explicit VisitMessage(CkMigrateMessage *msg) : deactivatedBy(DEACTIVATED_BY_NONE) {}
   VisitMessage(Id locationIdx_, Id personIdx_, DiseaseState personState_,
       Time visitStart_, Time visitEnd_, double transmissionModifier_) :
     locationIdx(locationIdx_), personIdx(personIdx_),
     personState(personState_), visitStart(visitStart_),
     visitEnd(visitEnd_), transmissionModifier(transmissionModifier_),
-    deactivatedBy(NULL) {}
+    deactivatedBy(DEACTIVATED_BY_NONE) {}
 
-  bool isActive() {
-    return NULL != deactivatedBy;
+  bool isActive() const {
+    return DEACTIVATED_BY_NONE == deactivatedBy;
   }
 };
 PUPbytes(VisitMessage);
@@ -121,7 +123,7 @@ struct PersonStatesMessage {
 };
 
 struct VisitInterventionMessage {
-  PartitionId interventionIdx;
+  int interventionIdx;
   std::unordered_set<Id> affectedPeople;
   std::unordered_set<Id> previouslyAffectedPeople;
 

--- a/src/People.cpp
+++ b/src/People.cpp
@@ -504,12 +504,9 @@ void People::ReceiveIntervention(int interventionIdx) {
   InterventionModel *interventions = scenario->interventionModel;
   std::unordered_set<Id> applied;
   std::unordered_set<Id> removed;
-  //CkPrintf("    Person chare %d: applying intervention %d\n", thisIndex, interventionIdx);
   interventions->applyIntervention(interventionIdx, &people, &applied, &removed);
 
   if (applied.size() > 0 || removed.size() > 0) {
-    //CkPrintf("  Person chare %d: intervention %d applied to %ld and removed from %ld\n",
-    //  thisIndex, interventionIdx, applied.size(), removed.size());
     updateVisitedLocationsForIntervention(interventionIdx, &applied, &removed);
   }
 }

--- a/src/People.cpp
+++ b/src/People.cpp
@@ -504,9 +504,12 @@ void People::ReceiveIntervention(int interventionIdx) {
   InterventionModel *interventions = scenario->interventionModel;
   std::unordered_set<Id> applied;
   std::unordered_set<Id> removed;
+  //CkPrintf("    Person chare %d: applying intervention %d\n", thisIndex, interventionIdx);
   interventions->applyIntervention(interventionIdx, &people, &applied, &removed);
 
   if (applied.size() > 0 || removed.size() > 0) {
+    //CkPrintf("  Person chare %d: intervention %d applied to %ld and removed from %ld\n",
+    //  thisIndex, interventionIdx, applied.size(), removed.size());
     updateVisitedLocationsForIntervention(interventionIdx, &applied, &removed);
   }
 }

--- a/src/People.cpp
+++ b/src/People.cpp
@@ -501,14 +501,8 @@ void People::ReceiveInteractions(InteractionMessage interMsg) {
 }
 
 void People::ReceiveIntervention(int interventionIdx) {
-  const Intervention<Person> &inter =
-    scenario->interventionModel->getPersonIntervention(interventionIdx);
-  for (Person &person : people) {
-    if (person.willComply(interventionIdx)
-        && inter.test(person, person.getGenerator())) {
-      inter.apply(&person);
-    }
-  }
+  InterventionModel *interventions = scenario->interventionModel;
+  interventions->applyIntervention(interventionIdx, &people);
 }
 
 void People::EndOfDayStateUpdate() {

--- a/src/People.cpp
+++ b/src/People.cpp
@@ -502,7 +502,34 @@ void People::ReceiveInteractions(InteractionMessage interMsg) {
 
 void People::ReceiveIntervention(int interventionIdx) {
   InterventionModel *interventions = scenario->interventionModel;
-  interventions->applyIntervention(interventionIdx, &people);
+  std::unordered_set<Id> applied;
+  std::unordered_set<Id> removed;
+  interventions->applyIntervention(interventionIdx, &people, &applied, &removed);
+
+  if (applied.size() > 0 || removed.size() > 0) {
+    updateVisitedLocationsForIntervention(interventionIdx, &applied, &removed);
+  }
+}
+
+void People::updateVisitedLocationsForIntervention(int interventionIdx,
+    std::unordered_set<Id> *applied, std::unordered_set<Id> *removed) {
+  const Partitioner *partitioner = scenario->partitioner;
+  for (auto &entry : visitorsToPartition) {
+    PartitionId partitionIdx = entry.first;
+    const std::unordered_set<Id> &visitors = entry.second;
+
+    std::unordered_set<Id> partitionApplied;
+    std::unordered_set<Id> partitionRemoved;
+    set_intersection(visitors.begin(), visitors.end(),
+        applied->begin(), applied->end(),
+        std::inserter(partitionApplied, partitionApplied.begin()));
+    set_intersection(visitors.begin(), visitors.end(),
+        removed->begin(), removed->end(),
+        std::inserter(partitionRemoved, partitionRemoved.begin()));
+
+    VisitInterventionMessage msg(interventionIdx, partitionApplied, partitionRemoved);
+    locationsArray[partitionIdx].ReceiveVisitIntervention(msg);
+  }
 }
 
 void People::EndOfDayStateUpdate() {

--- a/src/People.h
+++ b/src/People.h
@@ -43,6 +43,8 @@ class People : public CBase_People {
   void ProcessInteractions(Person *person);
   void UpdateDiseaseState(Person *person);
   void loadPeopleData(std::string scenarioPath);
+  void updateVisitedLocationsForIntervention(int interventionIdx,
+    std::unordered_set<Id> *applied, std::unordered_set<Id> *removed);
 
  public:
   explicit People(int seed, std::string scenarioPath);

--- a/src/Person.cpp
+++ b/src/Person.cpp
@@ -25,9 +25,9 @@ Person::Person(const AttributeTable &attributes, int numInterventions,
   visitsByDay.resize(numDays);
 }
 
-void Person::filterVisits(const void *cause, VisitTest keepVisit) {}
+void Person::filterVisits(InterventionId interventionId, VisitTest keepVisit) {}
 
-void Person::restoreVisits(const void *cause, VisitTest restoreVisit) {}
+void Person::restoreVisits(InterventionId interventionId, VisitTest restoreVisit) {}
 
 void Person::pup(PUP::er &p) {
   p | uniqueId;

--- a/src/Person.cpp
+++ b/src/Person.cpp
@@ -25,11 +25,9 @@ Person::Person(const AttributeTable &attributes, int numInterventions,
   visitsByDay.resize(numDays);
 }
 
-void Person::filterVisits(const void *cause, VisitTest keepVisit) {
-}
+void Person::filterVisits(const void *cause, VisitTest keepVisit) {}
 
-void Person::restoreVisits(const void *cause) {
-}
+void Person::restoreVisits(const void *cause, VisitTest restoreVisit) {}
 
 void Person::pup(PUP::er &p) {
   p | uniqueId;

--- a/src/Person.cpp
+++ b/src/Person.cpp
@@ -26,23 +26,9 @@ Person::Person(const AttributeTable &attributes, int numInterventions,
 }
 
 void Person::filterVisits(const void *cause, VisitTest keepVisit) {
-  for (std::vector<VisitMessage> &visits : visitsByDay) {
-    for (int i = 0; i < visits.size(); ++i) {
-      if (!keepVisit(visits[i])) {
-        visits[i].deactivatedBy = cause;
-      }
-    }
-  }
 }
 
 void Person::restoreVisits(const void *cause) {
-  for (std::vector<VisitMessage> &visits : visitsByDay) {
-    for (int i = 0; i < visits.size(); ++i) {
-      if (cause == visits[i].deactivatedBy) {
-        visits[i].deactivatedBy = NULL;
-      }
-    }
-  }
 }
 
 void Person::pup(PUP::er &p) {

--- a/src/Person.h
+++ b/src/Person.h
@@ -38,8 +38,8 @@ class Person : public DataInterface {
   Person& operator=(const Person&) = default;
   Person& operator=(Person&&) = default;
   ~Person() = default;
-  void filterVisits(const void *cause, VisitTest keepVisit) override;
-  void restoreVisits(const void *cause, VisitTest restoreVisit) override;
+  void filterVisits(InterventionId interventionId, VisitTest keepVisit) override;
+  void restoreVisits(InterventionId interventionId, VisitTest restoreVisit) override;
   // Lets charm++ migrate objects
   void pup(PUP::er &p);  // NOLINT(runtime/references)
   // Debugging.

--- a/src/Person.h
+++ b/src/Person.h
@@ -39,7 +39,7 @@ class Person : public DataInterface {
   Person& operator=(Person&&) = default;
   ~Person() = default;
   void filterVisits(const void *cause, VisitTest keepVisit) override;
-  void restoreVisits(const void *cause) override;
+  void restoreVisits(const void *cause, VisitTest restoreVisit) override;
   // Lets charm++ migrate objects
   void pup(PUP::er &p);  // NOLINT(runtime/references)
   // Debugging.

--- a/src/Types.h
+++ b/src/Types.h
@@ -25,6 +25,11 @@ using PartitionId = int;
 #define PARTITION_ID_PRINT_TYPE "%d"
 #define PARTITION_ID_PARSE std::stoi
 
+// For keeping track of intervention status
+using InterventionStatus = uint8_t;
+#define INTERVENTION_WILL_COMPLY 1
+#define INTERVENTION_IS_ACTIVE 2
+
 // Disease states
 using DiseaseState = int;
 

--- a/src/Types.h
+++ b/src/Types.h
@@ -21,9 +21,13 @@ using Id = int64_t;
 #define ID_REDUCTION_TYPE long  // NOLINT(runtime/int)
 #define ID_PARSE std::stol
 
-using PartitionId = int;
+using PartitionId = int32_t;
 #define PARTITION_ID_PRINT_TYPE "%d"
 #define PARTITION_ID_PARSE std::stoi
+
+using InterventionId = int16_t;
+#define INTERVENTION_ID_PRINT_TYPE "%d"
+#define INTERVENTION_ID_PARSE std::stoi
 
 // For keeping track of intervention status
 using InterventionStatus = uint8_t;

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -53,6 +53,7 @@ class Intervention {
     if (isActive) {
       for (T &d : *data) {
         if (d.willComply(interventionIndex)
+            && !d.isActive(interventionIndex)
             && shouldApply(d, d.getGenerator())) {
           apply(&d);
         } else if (d.isActive(interventionIndex)

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -31,7 +31,10 @@ class Intervention {
   bool willComply(const T &p, std::default_random_engine *generator) const {
     return unitDistrib(*generator) < compliance;
   }
-  virtual bool test(const T &p, std::default_random_engine *generator) const {
+  virtual bool shouldApply(const T &p, std::default_random_engine *generator) const {
+    return false;
+  }
+  virtual bool shouldRemove(const T &p, std::default_random_engine *generator) const {
     return false;
   }
   // Applies intervention to object
@@ -39,6 +42,10 @@ class Intervention {
   // Undoes any previous intervention application on this object.
   // For any intervention that cannot be undone, this should have no effect.
   virtual void remove(T *p) const {}
+
+  static bool updatesVisits() {
+    return false;
+  }
 
   Intervention() {}
   Intervention(
@@ -48,7 +55,7 @@ class Intervention {
     compliance = interventionDef.compliance();
     triggerIndex = interventionDef.trigger_index();
   }
-};
+};  
 
 template <class T>
 std::uniform_real_distribution<double> Intervention<T>::unitDistrib(

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -31,7 +31,6 @@ class Intervention {
   const InterventionId interventionId;
 
  public:
-
   Intervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
@@ -77,8 +76,8 @@ class Intervention {
             && shouldRemove(d, d.getGenerator())) {
           d.toggleActivity(interventionId, false);
           remove(&d);
+        }
       }
-    }
 
     } else {
       for (T &d : *data) {

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -25,9 +25,10 @@ class Intervention {
   static std::uniform_real_distribution<double> unitDistrib;
   double compliance;
   int triggerIndex;
-  uint interventionIndex;
 
  public:
+  const uint interventionIndex;
+
   int getTriggerIndex() const {
     return triggerIndex;
   }
@@ -73,7 +74,6 @@ class Intervention {
     const std::unordered_set<Id> &applied,
     const std::unordered_set<Id> &removed) const {}
 
-  Intervention() {}
   Intervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -14,6 +14,7 @@
 #include "../Location.h"
 
 #include "charm++.h"
+#include <vector>
 #include <unordered_set>
 
 using InterventionList = google::protobuf::RepeatedPtrField<
@@ -68,7 +69,7 @@ class Intervention {
       }
     }
   }
-  
+
   virtual void apply(std::vector<Location> *data,
     const std::unordered_set<Id> &applied,
     const std::unordered_set<Id> &removed) const {}

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -11,8 +11,10 @@
 #include "../protobuf/disease.pb.h"
 #include "../readers/DataInterface.h"
 #include "../readers/AttributeTable.h"
+#include "../Location.h"
 
 #include "charm++.h"
+#include <unordered_set>
 
 using InterventionList = google::protobuf::RepeatedPtrField<
   loimos::proto::InterventionModel::Intervention>;
@@ -45,7 +47,8 @@ class Intervention {
   virtual void remove(T *p) const {}
 
   // Applies the intervention to or removes it from all objects on a chare
-  virtual void apply(std::vector<T> *data, bool isActive) const {
+  virtual void apply(std::vector<T> *data, bool isActive,
+      std::unordered_set<Id> *applied, std::unordered_set<Id> *removed) const {
     if (isActive) {
       for (T &d : *data) {
         if (d.willComply(interventionIndex)
@@ -65,6 +68,10 @@ class Intervention {
       }
     }
   }
+  
+  virtual void apply(std::vector<Location> *data,
+    const std::unordered_set<Id> &applied,
+    const std::unordered_set<Id> &removed) const {}
 
   Intervention() {}
   Intervention(
@@ -75,7 +82,7 @@ class Intervention {
     compliance = interventionDef.compliance();
     triggerIndex = interventionDef.trigger_index();
   }
-};  
+};
 
 template <class T>
 std::uniform_real_distribution<double> Intervention<T>::unitDistrib(

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -11,6 +11,8 @@
 #include "../protobuf/disease.pb.h"
 #include "../readers/DataInterface.h"
 #include "../readers/AttributeTable.h"
+#include "../Types.h"
+#include "../Person.h"
 #include "../Location.h"
 
 #include "charm++.h"
@@ -24,13 +26,27 @@ template <class T = DataInterface>
 class Intervention {
  protected:
   static std::uniform_real_distribution<double> unitDistrib;
-  double compliance;
-  int triggerIndex;
-  const uint interventionIndex;
+  const double compliance;
+  const InterventionId triggerIndex;
+  const InterventionId interventionId;
 
  public:
+
+  Intervention(
+      const loimos::proto::InterventionModel::Intervention &interventionDef,
+      const loimos::proto::DiseaseModel &diseaseDef,
+      const AttributeTable &t, InterventionId _interventionId) :
+      interventionId(_interventionId),
+      compliance(interventionDef.compliance()),
+      triggerIndex(interventionDef.trigger_index()) {}
+
   int getTriggerIndex() const {
     return triggerIndex;
+  }
+  // Meant to uniquely identify an intervention, regardless of whether
+  // it is applied to people or locations
+  InterventionId getInterventionId() const {
+    return interventionId;
   }
   bool willComply(const T &p, std::default_random_engine *generator) const {
     return unitDistrib(*generator) < compliance;
@@ -52,19 +68,22 @@ class Intervention {
       std::unordered_set<Id> *applied, std::unordered_set<Id> *removed) const {
     if (isActive) {
       for (T &d : *data) {
-        if (d.willComply(interventionIndex)
-            && !d.isActive(interventionIndex)
+        if (d.willComply(interventionId)
+            && !d.isActive(interventionId)
             && shouldApply(d, d.getGenerator())) {
+          d.toggleActivity(interventionId, true);
           apply(&d);
-        } else if (d.isActive(interventionIndex)
+        } else if (d.isActive(interventionId)
             && shouldRemove(d, d.getGenerator())) {
+          d.toggleActivity(interventionId, false);
           remove(&d);
       }
     }
 
     } else {
       for (T &d : *data) {
-        if (d.isActive(interventionIndex)) {
+        if (d.isActive(interventionId)) {
+          d.toggleActivity(interventionId, false);
           remove(&d);
         }
       }
@@ -74,15 +93,6 @@ class Intervention {
   virtual void apply(std::vector<Location> *data,
     const std::unordered_set<Id> &applied,
     const std::unordered_set<Id> &removed) const {}
-
-  Intervention(
-      const loimos::proto::InterventionModel::Intervention &interventionDef,
-      const loimos::proto::DiseaseModel &diseaseDef,
-      const AttributeTable &t, uint _interventionIndex) :
-      interventionIndex(_interventionIndex) {
-    compliance = interventionDef.compliance();
-    triggerIndex = interventionDef.trigger_index();
-  }
 };
 
 template <class T>

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -25,10 +25,9 @@ class Intervention {
   static std::uniform_real_distribution<double> unitDistrib;
   double compliance;
   int triggerIndex;
-
- public:
   const uint interventionIndex;
 
+ public:
   int getTriggerIndex() const {
     return triggerIndex;
   }
@@ -56,8 +55,8 @@ class Intervention {
             && shouldApply(d, d.getGenerator())) {
           apply(&d);
         } else if (d.isActive(interventionIndex)
-          && shouldRemove(d, d.getGenerator())) {
-        remove(&d);
+            && shouldRemove(d, d.getGenerator())) {
+          remove(&d);
       }
     }
 

--- a/src/intervention_model/Intervention.h
+++ b/src/intervention_model/Intervention.h
@@ -23,6 +23,7 @@ class Intervention {
   static std::uniform_real_distribution<double> unitDistrib;
   double compliance;
   int triggerIndex;
+  uint interventionIndex;
 
  public:
   int getTriggerIndex() const {
@@ -43,15 +44,34 @@ class Intervention {
   // For any intervention that cannot be undone, this should have no effect.
   virtual void remove(T *p) const {}
 
-  static bool updatesVisits() {
-    return false;
+  // Applies the intervention to or removes it from all objects on a chare
+  virtual void apply(std::vector<T> *data, bool isActive) const {
+    if (isActive) {
+      for (T &d : *data) {
+        if (d.willComply(interventionIndex)
+            && shouldApply(d, d.getGenerator())) {
+          apply(&d);
+        } else if (d.isActive(interventionIndex)
+          && shouldRemove(d, d.getGenerator())) {
+        remove(&d);
+      }
+    }
+
+    } else {
+      for (T &d : *data) {
+        if (d.isActive(interventionIndex)) {
+          remove(&d);
+        }
+      }
+    }
   }
 
   Intervention() {}
   Intervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
-      const AttributeTable &t) {
+      const AttributeTable &t, uint _interventionIndex) :
+      interventionIndex(_interventionIndex) {
     compliance = interventionDef.compliance();
     triggerIndex = interventionDef.trigger_index();
   }

--- a/src/intervention_model/InterventionModel.cpp
+++ b/src/intervention_model/InterventionModel.cpp
@@ -55,13 +55,14 @@ void InterventionModel::initLocationInterventions(
     const InterventionList &interventionSpecs,
     const AttributeTable &attributes,
     const DiseaseModel &diseaseModel) {
+  uint offset = personInterventions.size();
   for (uint i = 0; i < interventionSpecs.size(); ++i) {
     const loimos::proto::InterventionModel::Intervention &spec =
       interventionSpecs[i];
 
     if (spec.has_school_closures()) {
       locationInterventions.emplace_back(new SchoolClosureIntervention(
-        spec, *diseaseModel.model, attributes, i));
+        spec, *diseaseModel.model, attributes, i + offset));
     }
   }
 }

--- a/src/intervention_model/InterventionModel.cpp
+++ b/src/intervention_model/InterventionModel.cpp
@@ -76,6 +76,16 @@ const Intervention<Location> & InterventionModel::getLocationIntervention(int in
   return *locationInterventions[index];
 }
 
+template <>
+const Intervention<Location> &InterventionModel::getIntervention(int index) const {
+  return getLocationIntervention(index);
+}
+
+template <>
+const Intervention<Person> &InterventionModel::getIntervention(int index) const {
+  return getPersonIntervention(index);
+}
+
 int InterventionModel::getNumPersonInterventions() const {
   return static_cast<int>(personInterventions.size());
 }
@@ -86,15 +96,20 @@ int InterventionModel::getNumLocationInterventions() const {
 
 void InterventionModel::applyInterventions(int day, Id newDailyInfections,
     Id numPeople) {
+  std::vector<bool> prevTriggerFlags;
+  prevTriggerFlags.insert(prevTriggerFlags.end(), triggerFlags.begin(),
+      triggerFlags.end());
   toggleInterventions(day, newDailyInfections, numPeople);
 
   for (uint i = 0; i < personInterventions.size(); ++i) {
-    if (triggerFlags[personInterventions[i]->getTriggerIndex()]) {
+    int triggerIndex = personInterventions[i]->getTriggerIndex();
+    if (triggerFlags[triggerIndex] || prevTriggerFlags[triggerIndex]) {
       peopleArray.ReceiveIntervention(i);
     }
   }
   for (uint i = 0; i < locationInterventions.size(); ++i) {
-    if (triggerFlags[locationInterventions[i]->getTriggerIndex()]) {
+    int triggerIndex = personInterventions[i]->getTriggerIndex();
+    if (triggerFlags[triggerIndex] || prevTriggerFlags[triggerIndex]) {
       locationsArray.ReceiveIntervention(i);
     }
   }

--- a/src/intervention_model/InterventionModel.cpp
+++ b/src/intervention_model/InterventionModel.cpp
@@ -42,11 +42,11 @@ void InterventionModel::initPersonInterventions(
 
     if (spec.has_self_isolation()) {
       personInterventions.emplace_back(new SelfIsolationIntervention(
-        spec, *diseaseModel.model, attributes));
+        spec, *diseaseModel.model, attributes, i));
 
     } else if (spec.has_vaccination()) {
       personInterventions.emplace_back(new VaccinationIntervention(
-        spec, *diseaseModel.model, attributes));
+        spec, *diseaseModel.model, attributes, i));
     }
   }
 }
@@ -61,7 +61,7 @@ void InterventionModel::initLocationInterventions(
 
     if (spec.has_school_closures()) {
       locationInterventions.emplace_back(new SchoolClosureIntervention(
-        spec, *diseaseModel.model, attributes));
+        spec, *diseaseModel.model, attributes, i));
     }
   }
 }

--- a/src/intervention_model/InterventionModel.h
+++ b/src/intervention_model/InterventionModel.h
@@ -36,9 +36,37 @@ struct InterventionModel {
 
   const Intervention<Person> &getPersonIntervention(int index) const;
   const Intervention<Location> &getLocationIntervention(int index) const;
+  template <class T = DataInterface>
+  const Intervention<T> &getIntervention(int index) const;
+
   int getNumPersonInterventions() const;
   int getNumLocationInterventions() const;
   void applyInterventions(int day, Id newDailyInfections, Id numPeople);
   void toggleInterventions(int day, Id newDailyInfections, Id numPeople);
+
+  template <class T = DataInterface>
+  void applyIntervention(int interventionIdx, std::vector<T> *data) const {
+    const Intervention<T> &inter = getIntervention<T>(interventionIdx);
+    bool isActive = triggerFlags[inter.getTriggerIndex()];
+
+    if (isActive) {
+      for (T &d : *data) {
+        if (d.willComply(interventionIdx)
+            && inter.shouldApply(d, d.getGenerator())) {
+          inter.apply(&d);
+        } else if (d.isActive(interventionIdx)
+          && inter.shouldRemove(d, d.getGenerator())) {
+        inter.remove(&d);
+      }
+    }
+
+    } else {
+      for (T &d : *data) {
+        if (d.isActive(interventionIdx)) {
+          inter.remove(&d);
+        }
+      }
+    }
+  }
 };
 #endif  // INTERVENTION_MODEL_INTERVENTIONMODEL_H_

--- a/src/intervention_model/InterventionModel.h
+++ b/src/intervention_model/InterventionModel.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 struct InterventionModel {
   std::vector<bool> triggerFlags;
@@ -45,10 +46,11 @@ struct InterventionModel {
   void toggleInterventions(int day, Id newDailyInfections, Id numPeople);
 
   template <class T = DataInterface>
-  void applyIntervention(int interventionIdx, std::vector<T> *data) const {
+  void applyIntervention(int interventionIdx, std::vector<T> *data,
+      std::unordered_set<Id> *applied, std::unordered_set<Id> *removed) const {
     const Intervention<T> &inter = getIntervention<T>(interventionIdx);
     bool isActive = triggerFlags[inter.getTriggerIndex()];
-    inter.apply(data, isActive);
+    inter.apply(data, isActive, applied, removed);
   }
 };
 #endif  // INTERVENTION_MODEL_INTERVENTIONMODEL_H_

--- a/src/intervention_model/InterventionModel.h
+++ b/src/intervention_model/InterventionModel.h
@@ -48,25 +48,7 @@ struct InterventionModel {
   void applyIntervention(int interventionIdx, std::vector<T> *data) const {
     const Intervention<T> &inter = getIntervention<T>(interventionIdx);
     bool isActive = triggerFlags[inter.getTriggerIndex()];
-
-    if (isActive) {
-      for (T &d : *data) {
-        if (d.willComply(interventionIdx)
-            && inter.shouldApply(d, d.getGenerator())) {
-          inter.apply(&d);
-        } else if (d.isActive(interventionIdx)
-          && inter.shouldRemove(d, d.getGenerator())) {
-        inter.remove(&d);
-      }
-    }
-
-    } else {
-      for (T &d : *data) {
-        if (d.isActive(interventionIdx)) {
-          inter.remove(&d);
-        }
-      }
-    }
+    inter.apply(data, isActive);
   }
 };
 #endif  // INTERVENTION_MODEL_INTERVENTIONMODEL_H_

--- a/src/intervention_model/SchoolClosureIntervention.h
+++ b/src/intervention_model/SchoolClosureIntervention.h
@@ -17,15 +17,14 @@
 
 class SchoolClosureIntervention : public VisitFilterIntervention<Location> {
  protected:
-  int schoolIndex;
+  const int schoolIndex;
  public:
   SchoolClosureIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
-      const AttributeTable &t, uint index) :
-    VisitFilterIntervention<Location>(interventionDef, diseaseDef, t, index) {
-    schoolIndex = t.getAttributeIndex("school");
-  }
+      const AttributeTable &t, InterventionId id) :
+    VisitFilterIntervention<Location>(interventionDef, diseaseDef, t, id),
+    schoolIndex(t.getAttributeIndex("school")) {}
 
   bool shouldApply(const Location &p,
       std::default_random_engine *generator) const override {

--- a/src/intervention_model/SchoolClosureIntervention.h
+++ b/src/intervention_model/SchoolClosureIntervention.h
@@ -22,8 +22,8 @@ class SchoolClosureIntervention : public VisitFilterIntervention<Location> {
   SchoolClosureIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
-      const AttributeTable &t) :
-    VisitFilterIntervention<Location>(interventionDef, diseaseDef, t) {
+      const AttributeTable &t, uint index) :
+    VisitFilterIntervention<Location>(interventionDef, diseaseDef, t, index) {
     schoolIndex = t.getAttributeIndex("school");
   }
 

--- a/src/intervention_model/SchoolClosureIntervention.h
+++ b/src/intervention_model/SchoolClosureIntervention.h
@@ -27,7 +27,7 @@ class SchoolClosureIntervention : public VisitFilterIntervention<Location> {
     schoolIndex = t.getAttributeIndex("school");
   }
 
-  bool test(const Location &p, std::default_random_engine *generator) const override {
+  bool shouldApply(const Location &p, std::default_random_engine *generator) const override {
     return p.getValue(schoolIndex).bool_val;
   }
 };

--- a/src/intervention_model/SchoolClosureIntervention.h
+++ b/src/intervention_model/SchoolClosureIntervention.h
@@ -27,7 +27,8 @@ class SchoolClosureIntervention : public VisitFilterIntervention<Location> {
     schoolIndex = t.getAttributeIndex("school");
   }
 
-  bool shouldApply(const Location &p, std::default_random_engine *generator) const override {
+  bool shouldApply(const Location &p,
+      std::default_random_engine *generator) const override {
     return p.getValue(schoolIndex).bool_val;
   }
 };

--- a/src/intervention_model/SelfIsolationIntervention.h
+++ b/src/intervention_model/SelfIsolationIntervention.h
@@ -27,8 +27,11 @@ class SelfIsolationIntervention : public VisitFilterIntervention<Person> {
       const loimos::proto::DiseaseModel &diseaseDef_,
       const AttributeTable &t) : diseaseDef(diseaseDef_),
     VisitFilterIntervention<Person>(interventionDef, diseaseDef_, t) {}
-  virtual bool test(const Person &p, std::default_random_engine *generator) const {
+  virtual bool shouldApply(const Person &p, std::default_random_engine *generator) const {
     return diseaseDef.disease_states(p.state).symptomatic();
+  }
+  virtual bool shouldRemove(const Person &p, std::default_random_engine *generator) const {
+    return !diseaseDef.disease_states(p.state).symptomatic();
   }
 };
 

--- a/src/intervention_model/SelfIsolationIntervention.h
+++ b/src/intervention_model/SelfIsolationIntervention.h
@@ -25,8 +25,8 @@ class SelfIsolationIntervention : public VisitFilterIntervention<Person> {
   SelfIsolationIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef_,
-      const AttributeTable &t) : diseaseDef(diseaseDef_),
-    VisitFilterIntervention<Person>(interventionDef, diseaseDef_, t) {}
+      const AttributeTable &t, uint index) : diseaseDef(diseaseDef_),
+    VisitFilterIntervention<Person>(interventionDef, diseaseDef_, t, index) {}
   virtual bool shouldApply(const Person &p, std::default_random_engine *generator) const {
     return diseaseDef.disease_states(p.state).symptomatic();
   }

--- a/src/intervention_model/SelfIsolationIntervention.h
+++ b/src/intervention_model/SelfIsolationIntervention.h
@@ -27,12 +27,14 @@ class SelfIsolationIntervention : public VisitFilterIntervention<Person> {
       const loimos::proto::DiseaseModel &diseaseDef_,
       const AttributeTable &t, uint index) : diseaseDef(diseaseDef_),
     VisitFilterIntervention<Person>(interventionDef, diseaseDef_, t, index) {}
-  virtual bool shouldApply(const Person &p,
-      std::default_random_engine *generator) const {
+
+  bool shouldApply(const Person &p,
+      std::default_random_engine *generator) const override {
     return diseaseDef.disease_states(p.state).symptomatic();
   }
-  virtual bool shouldRemove(const Person &p,
-      std::default_random_engine *generator) const {
+
+  bool shouldRemove(const Person &p,
+      std::default_random_engine *generator) const override {
     return !diseaseDef.disease_states(p.state).symptomatic();
   }
 };

--- a/src/intervention_model/SelfIsolationIntervention.h
+++ b/src/intervention_model/SelfIsolationIntervention.h
@@ -19,14 +19,13 @@
 
 class SelfIsolationIntervention : public VisitFilterIntervention<Person> {
  protected:
-  int schoolIndex;
   const loimos::proto::DiseaseModel &diseaseDef;
  public:
   SelfIsolationIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef_,
-      const AttributeTable &t, uint index) : diseaseDef(diseaseDef_),
-    VisitFilterIntervention<Person>(interventionDef, diseaseDef_, t, index) {}
+      const AttributeTable &t, InterventionId id) : diseaseDef(diseaseDef_),
+    VisitFilterIntervention<Person>(interventionDef, diseaseDef_, t, id) {}
 
   bool shouldApply(const Person &p,
       std::default_random_engine *generator) const override {

--- a/src/intervention_model/SelfIsolationIntervention.h
+++ b/src/intervention_model/SelfIsolationIntervention.h
@@ -27,10 +27,12 @@ class SelfIsolationIntervention : public VisitFilterIntervention<Person> {
       const loimos::proto::DiseaseModel &diseaseDef_,
       const AttributeTable &t, uint index) : diseaseDef(diseaseDef_),
     VisitFilterIntervention<Person>(interventionDef, diseaseDef_, t, index) {}
-  virtual bool shouldApply(const Person &p, std::default_random_engine *generator) const {
+  virtual bool shouldApply(const Person &p,
+      std::default_random_engine *generator) const {
     return diseaseDef.disease_states(p.state).symptomatic();
   }
-  virtual bool shouldRemove(const Person &p, std::default_random_engine *generator) const {
+  virtual bool shouldRemove(const Person &p,
+      std::default_random_engine *generator) const {
     return !diseaseDef.disease_states(p.state).symptomatic();
   }
 };

--- a/src/intervention_model/VaccinationIntervention.cpp
+++ b/src/intervention_model/VaccinationIntervention.cpp
@@ -15,8 +15,8 @@
 VaccinationIntervention::VaccinationIntervention(
     const loimos::proto::InterventionModel::Intervention &interventionDef,
     const loimos::proto::DiseaseModel &diseaseDef,
-    const AttributeTable &t) :
-  Intervention(interventionDef, diseaseDef, t) {
+    const AttributeTable &t, uint index) :
+  Intervention(interventionDef, diseaseDef, t, index) {
   vaccinationProbability = interventionDef.vaccination().probability();
   vaccinatedSusceptibility = interventionDef.vaccination()
     .vaccinated_susceptibility();

--- a/src/intervention_model/VaccinationIntervention.cpp
+++ b/src/intervention_model/VaccinationIntervention.cpp
@@ -15,8 +15,8 @@
 VaccinationIntervention::VaccinationIntervention(
     const loimos::proto::InterventionModel::Intervention &interventionDef,
     const loimos::proto::DiseaseModel &diseaseDef,
-    const AttributeTable &t, uint index) :
-  Intervention(interventionDef, diseaseDef, t, index) {
+    const AttributeTable &t, InterventionId id) :
+  Intervention(interventionDef, diseaseDef, t, id) {
   vaccinationProbability = interventionDef.vaccination().probability();
   vaccinatedSusceptibility = interventionDef.vaccination()
     .vaccinated_susceptibility();

--- a/src/intervention_model/VaccinationIntervention.cpp
+++ b/src/intervention_model/VaccinationIntervention.cpp
@@ -26,7 +26,7 @@ VaccinationIntervention::VaccinationIntervention(
   this->susceptibilityIndex = t.getAttributeIndex("susceptibility");
 }
 
-bool VaccinationIntervention::test(const Person &p,
+bool VaccinationIntervention::shouldApply(const Person &p,
     std::default_random_engine *generator) const {
   return !p.getValue(vaccinatedIndex).bool_val
     && unitDistrib(*generator) < vaccinationProbability;

--- a/src/intervention_model/VaccinationIntervention.h
+++ b/src/intervention_model/VaccinationIntervention.h
@@ -28,7 +28,6 @@ class VaccinationIntervention : public Intervention<Person> {
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
       const AttributeTable &t, uint index);
-  VaccinationIntervention() {}
 
   bool shouldApply(const Person &p, std::default_random_engine *generator)
       const override;

--- a/src/intervention_model/VaccinationIntervention.h
+++ b/src/intervention_model/VaccinationIntervention.h
@@ -30,7 +30,7 @@ class VaccinationIntervention : public Intervention<Person> {
       const AttributeTable &t);
   VaccinationIntervention() {}
 
-  bool test(const Person &p, std::default_random_engine *generator)
+  bool shouldApply(const Person &p, std::default_random_engine *generator)
       const override;
   void apply(Person *p) const override;
 };

--- a/src/intervention_model/VaccinationIntervention.h
+++ b/src/intervention_model/VaccinationIntervention.h
@@ -27,7 +27,7 @@ class VaccinationIntervention : public Intervention<Person> {
   VaccinationIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
-      const AttributeTable &t, uint index);
+      const AttributeTable &t, InterventionId id);
 
   bool shouldApply(const Person &p, std::default_random_engine *generator)
       const override;

--- a/src/intervention_model/VaccinationIntervention.h
+++ b/src/intervention_model/VaccinationIntervention.h
@@ -27,7 +27,7 @@ class VaccinationIntervention : public Intervention<Person> {
   VaccinationIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
-      const AttributeTable &t);
+      const AttributeTable &t, uint index);
   VaccinationIntervention() {}
 
   bool shouldApply(const Person &p, std::default_random_engine *generator)

--- a/src/intervention_model/VisitFilterIntervention.h
+++ b/src/intervention_model/VisitFilterIntervention.h
@@ -29,11 +29,16 @@ class VisitFilterIntervention : public Intervention<T> {
     };
   }
 
-  void apply(T *p) const override {
-    p->filterVisits(this, keepVisit);
+  void apply(T *d) const override {
+    d->filterVisits(this, keepVisit);
   }
-  void remove(T *p) const override {
-    p->restoreVisits(this);
+
+  void remove(T *d) const override {
+    d->restoreVisits(this);
+  }
+  
+  static bool updatesVisits() {
+    return true;
   }
 };
 

--- a/src/intervention_model/VisitFilterIntervention.h
+++ b/src/intervention_model/VisitFilterIntervention.h
@@ -69,6 +69,7 @@ class VisitFilterIntervention : public Intervention<T> {
     if (isActive) {
       for (T &d : *data) {
         if (d.willComply(this->interventionIndex)
+            && !d.isActive(this->interventionIndex)
             && this->shouldApply(d, d.getGenerator())) {
           applied->emplace(d.getUniqueId());
         } else if (d.isActive(this->interventionIndex)
@@ -107,14 +108,11 @@ class VisitFilterIntervention : public Intervention<T> {
       return applied.find(visit.personIdx) == applied.end() && keepVisit(visit);
     };
     VisitTest inRemoved = [&](const VisitMessage &visit) {
-      return removed.find(visit.personIdx) != removed.end() || restoreVisit(visit);
+      return removed.find(visit.personIdx) != removed.end() && restoreVisit(visit);
     };
     for (Location &d : *data) {
-      if (applied.find(d.getUniqueId()) != applied.end()) {
-        d.filterVisits(this, notInApplied);
-      } else if (removed.find(d.getUniqueId()) != removed.end()) {
-        d.restoreVisits(this, inRemoved);
-      }
+      d.filterVisits(this, notInApplied);
+      d.restoreVisits(this, inRemoved);
     }
   }
 };

--- a/src/intervention_model/VisitFilterIntervention.h
+++ b/src/intervention_model/VisitFilterIntervention.h
@@ -8,12 +8,14 @@
 #define INTERVENTION_MODEL_VISITFILTERINTERVENTION_H_
 
 #include "../protobuf/interventions.pb.h"
+#include "Intervention.h"
 #include "../readers/DataInterface.h"
 #include "../readers/AttributeTable.h"
 
 #include "charm++.h"
 #include <functional>
 #include <unordered_set>
+#include <type_traits>
 
 template <class T = DataInterface>
 class VisitFilterIntervention : public Intervention<T> {
@@ -38,53 +40,72 @@ class VisitFilterIntervention : public Intervention<T> {
     d->restoreVisits(this);
   }
 
-  void apply(std::vector<Person> *data, bool isActive,
-    std::unordered_set<Id> *applied,
-    std::unordered_set<Id> *removed) const override;
-  
-  virtual void apply(std::vector<Location> *data,
-    const std::unordered_set<Id> &applied,
-    const std::unordered_set<Id> &removed) const override;
-};
-
-template <>
-void VisitFilterIntervention<Person>::apply(std::vector<Person> *data, bool isActive,
-    std::unordered_set<Id> *applied,
-    std::unordered_set<Id> *removed) const {
-  if (isActive) {
-    for (T &d : *data) {
-      if (d.willComply(interventionIndex)
-          && shouldApply(d, d.getGenerator())) {
-        applied->add(d.getUniqueId());
-      } else if (d.isActive(interventionIndex)
-        && shouldRemove(d, d.getGenerator())) {
-        removed->add(d.getUniqueId());
-    }
+  // This just exists to dispatch to the other two implementations
+  void apply(std::vector<T> *data, bool isActive,
+      std::unordered_set<Id> *applied,
+      std::unordered_set<Id> *removed) const override {
+    apply(data, isActive, applied, removed, std::is_same<T, Person>());
   }
 
-  } else {
-    for (T &d : *data) {
-      if (d.isActive(interventionIndex)) {
-        removed->add(d.getUniqueId());
+  void apply(std::vector<T> *data, bool isActive,
+      std::unordered_set<Id> *applied,
+      std::unordered_set<Id> *removed,
+      std::false_type) const {
+    Intervention<T>::apply(data, isActive, applied, removed);
+  }
+
+  void apply(std::vector<T> *data, bool isActive,
+      std::unordered_set<Id> *applied,
+      std::unordered_set<Id> *removed,
+      std::true_type) const {
+    if (isActive) {
+      for (T &d : *data) {
+        if (d.willComply(this->interventionIndex)
+            && this->shouldApply(d, d.getGenerator())) {
+          applied->emplace(d.getUniqueId());
+        } else if (d.isActive(this->interventionIndex)
+          && this->shouldRemove(d, d.getGenerator())) {
+          removed->emplace(d.getUniqueId());
+      }
+    }
+
+    } else {
+      for (T &d : *data) {
+        if (d.isActive(this->interventionIndex)) {
+          removed->emplace(d.getUniqueId());
+        }
       }
     }
   }
-}
 
-template <>
-void VisitFilterIntervention<Person>::apply(std::vector<Location> *data,
-    const std::unordered_set<Id> &applied,
-    const std::unordered_set<Id> &removed) const {
-  VisitTest notInApplied = [&applied](const VisitMessage &visit) {
-    return applied.find(visit.getPersonId()) == applied.end();
-  };
-  for (Location &d : *data) {
-    if (applied.find(d.getUniqueId()) != applied.end()) {
-      d.filterVisits(this, notInApplied);
-    } else if (removed.find(d.getUniqueId()) != removed.end()) {
-      d.restoreVisits(this);
+  // This just exists to dispatch to the other two implementations
+  void apply(std::vector<Location> *data,
+      const std::unordered_set<Id> &applied,
+      const std::unordered_set<Id> &removed) const {
+    apply(data, applied, removed, std::is_same<T, Person>());
+  }
+
+  void apply(std::vector<Location> *data,
+      const std::unordered_set<Id> &applied,
+      const std::unordered_set<Id> &removed,
+      std::false_type) const {}
+
+  void apply(std::vector<Location> *data,
+      const std::unordered_set<Id> &applied,
+      const std::unordered_set<Id> &removed,
+      std::true_type) const {
+    VisitTest notInApplied = [&](const VisitMessage &visit) {
+      return applied.find(visit.personIdx) == applied.end();
+    };
+    for (Location &d : *data) {
+      if (applied.find(d.getUniqueId()) != applied.end()) {
+        d.filterVisits(this, notInApplied);
+      } else if (removed.find(d.getUniqueId()) != removed.end()) {
+        d.restoreVisits(this);
+      }
     }
   }
-}
+};
+
 
 #endif  // INTERVENTION_MODEL_VISITFILTERINTERVENTION_H_

--- a/src/intervention_model/VisitFilterIntervention.h
+++ b/src/intervention_model/VisitFilterIntervention.h
@@ -13,6 +13,7 @@
 
 #include "charm++.h"
 #include <functional>
+#include <unordered_set>
 
 template <class T = DataInterface>
 class VisitFilterIntervention : public Intervention<T> {
@@ -36,6 +37,54 @@ class VisitFilterIntervention : public Intervention<T> {
   void remove(T *d) const override {
     d->restoreVisits(this);
   }
+
+  void apply(std::vector<Person> *data, bool isActive,
+    std::unordered_set<Id> *applied,
+    std::unordered_set<Id> *removed) const override;
+  
+  virtual void apply(std::vector<Location> *data,
+    const std::unordered_set<Id> &applied,
+    const std::unordered_set<Id> &removed) const override;
 };
+
+template <>
+void VisitFilterIntervention<Person>::apply(std::vector<Person> *data, bool isActive,
+    std::unordered_set<Id> *applied,
+    std::unordered_set<Id> *removed) const {
+  if (isActive) {
+    for (T &d : *data) {
+      if (d.willComply(interventionIndex)
+          && shouldApply(d, d.getGenerator())) {
+        applied->add(d.getUniqueId());
+      } else if (d.isActive(interventionIndex)
+        && shouldRemove(d, d.getGenerator())) {
+        removed->add(d.getUniqueId());
+    }
+  }
+
+  } else {
+    for (T &d : *data) {
+      if (d.isActive(interventionIndex)) {
+        removed->add(d.getUniqueId());
+      }
+    }
+  }
+}
+
+template <>
+void VisitFilterIntervention<Person>::apply(std::vector<Location> *data,
+    const std::unordered_set<Id> &applied,
+    const std::unordered_set<Id> &removed) const {
+  VisitTest notInApplied = [&applied](const VisitMessage &visit) {
+    return applied.find(visit.getPersonId()) == applied.end();
+  };
+  for (Location &d : *data) {
+    if (applied.find(d.getUniqueId()) != applied.end()) {
+      d.filterVisits(this, notInApplied);
+    } else if (removed.find(d.getUniqueId()) != removed.end()) {
+      d.restoreVisits(this);
+    }
+  }
+}
 
 #endif  // INTERVENTION_MODEL_VISITFILTERINTERVENTION_H_

--- a/src/intervention_model/VisitFilterIntervention.h
+++ b/src/intervention_model/VisitFilterIntervention.h
@@ -14,6 +14,7 @@
 
 #include "charm++.h"
 #include <functional>
+#include <vector>
 #include <unordered_set>
 #include <type_traits>
 
@@ -22,6 +23,7 @@ class VisitFilterIntervention : public Intervention<T> {
  protected:
   VisitTest keepVisit;
   VisitTest restoreVisit;
+
  public:
   VisitFilterIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,

--- a/src/intervention_model/VisitFilterIntervention.h
+++ b/src/intervention_model/VisitFilterIntervention.h
@@ -28,8 +28,8 @@ class VisitFilterIntervention : public Intervention<T> {
   VisitFilterIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
-      const AttributeTable &t, uint index) :
-    Intervention<T>(interventionDef, diseaseDef, t, index) {
+      const AttributeTable &t, InterventionId id) :
+    Intervention<T>(interventionDef, diseaseDef, t, id) {
     keepVisit = [](const VisitMessage &visit) {
       return false;
     };
@@ -39,11 +39,11 @@ class VisitFilterIntervention : public Intervention<T> {
   }
 
   void apply(T *d) const override {
-    d->filterVisits(this, keepVisit);
+    d->filterVisits(this->getInterventionId(), keepVisit);
   }
 
   void remove(T *d) const override {
-    d->restoreVisits(this, restoreVisit);
+    d->restoreVisits(this->getInterventionId(), restoreVisit);
   }
 
   // This just exists to dispatch to the other two implementations
@@ -68,19 +68,22 @@ class VisitFilterIntervention : public Intervention<T> {
       std::true_type) const {
     if (isActive) {
       for (T &d : *data) {
-        if (d.willComply(this->interventionIndex)
-            && !d.isActive(this->interventionIndex)
+        if (d.willComply(this->interventionId)
+            && !d.isActive(this->interventionId)
             && this->shouldApply(d, d.getGenerator())) {
+          d.toggleActivity(this->interventionId, true);
           applied->emplace(d.getUniqueId());
-        } else if (d.isActive(this->interventionIndex)
-          && this->shouldRemove(d, d.getGenerator())) {
+        } else if (d.isActive(this->interventionId)
+            && this->shouldRemove(d, d.getGenerator())) {
+          d.toggleActivity(this->interventionId, false);
           removed->emplace(d.getUniqueId());
       }
     }
 
     } else {
       for (T &d : *data) {
-        if (d.isActive(this->interventionIndex)) {
+        if (d.isActive(this->interventionId)) {
+          d.toggleActivity(this->interventionId, false);
           removed->emplace(d.getUniqueId());
         }
       }
@@ -111,8 +114,8 @@ class VisitFilterIntervention : public Intervention<T> {
       return removed.find(visit.personIdx) != removed.end() && restoreVisit(visit);
     };
     for (Location &d : *data) {
-      d.filterVisits(this, notInApplied);
-      d.restoreVisits(this, inRemoved);
+      d.filterVisits(this->getInterventionId(), notInApplied);
+      d.restoreVisits(this->getInterventionId(), inRemoved);
     }
   }
 };

--- a/src/intervention_model/VisitFilterIntervention.h
+++ b/src/intervention_model/VisitFilterIntervention.h
@@ -21,6 +21,7 @@ template <class T = DataInterface>
 class VisitFilterIntervention : public Intervention<T> {
  protected:
   VisitTest keepVisit;
+  VisitTest restoreVisit;
  public:
   VisitFilterIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
@@ -30,6 +31,9 @@ class VisitFilterIntervention : public Intervention<T> {
     keepVisit = [](const VisitMessage &visit) {
       return false;
     };
+    restoreVisit = [](const VisitMessage &visit) {
+      return true;
+    };
   }
 
   void apply(T *d) const override {
@@ -37,7 +41,7 @@ class VisitFilterIntervention : public Intervention<T> {
   }
 
   void remove(T *d) const override {
-    d->restoreVisits(this);
+    d->restoreVisits(this, restoreVisit);
   }
 
   // This just exists to dispatch to the other two implementations
@@ -54,6 +58,8 @@ class VisitFilterIntervention : public Intervention<T> {
     Intervention<T>::apply(data, isActive, applied, removed);
   }
 
+  // Visit filtering no longer occurs on person chares, so just keep
+  // track of affected people
   void apply(std::vector<T> *data, bool isActive,
       std::unordered_set<Id> *applied,
       std::unordered_set<Id> *removed,
@@ -90,18 +96,22 @@ class VisitFilterIntervention : public Intervention<T> {
       const std::unordered_set<Id> &removed,
       std::false_type) const {}
 
+  // Filters visits on Location chares based on the set of selected people
   void apply(std::vector<Location> *data,
       const std::unordered_set<Id> &applied,
       const std::unordered_set<Id> &removed,
       std::true_type) const {
     VisitTest notInApplied = [&](const VisitMessage &visit) {
-      return applied.find(visit.personIdx) == applied.end();
+      return applied.find(visit.personIdx) == applied.end() && keepVisit(visit);
+    };
+    VisitTest inRemoved = [&](const VisitMessage &visit) {
+      return removed.find(visit.personIdx) != removed.end() || restoreVisit(visit);
     };
     for (Location &d : *data) {
       if (applied.find(d.getUniqueId()) != applied.end()) {
         d.filterVisits(this, notInApplied);
       } else if (removed.find(d.getUniqueId()) != removed.end()) {
-        d.restoreVisits(this);
+        d.restoreVisits(this, inRemoved);
       }
     }
   }

--- a/src/intervention_model/VisitFilterIntervention.h
+++ b/src/intervention_model/VisitFilterIntervention.h
@@ -22,8 +22,8 @@ class VisitFilterIntervention : public Intervention<T> {
   VisitFilterIntervention(
       const loimos::proto::InterventionModel::Intervention &interventionDef,
       const loimos::proto::DiseaseModel &diseaseDef,
-      const AttributeTable &t) :
-    Intervention<T>(interventionDef, diseaseDef, t) {
+      const AttributeTable &t, uint index) :
+    Intervention<T>(interventionDef, diseaseDef, t, index) {
     keepVisit = [](const VisitMessage &visit) {
       return false;
     };
@@ -35,10 +35,6 @@ class VisitFilterIntervention : public Intervention<T> {
 
   void remove(T *d) const override {
     d->restoreVisits(this);
-  }
-  
-  static bool updatesVisits() {
-    return true;
   }
 };
 

--- a/src/loimos.ci
+++ b/src/loimos.ci
@@ -338,6 +338,7 @@ mainmodule loimos {
     entry AGGREGATE void ReceiveVisitMessages(VisitMessage);
     entry void ComputeInteractions(); // calls ReceiveInteractions
     entry void ReceiveIntervention(int interventionIdx);
+    entry void ReceiveVisitIntervention(VisitInterventionMessage msg);
     entry void AtSync();
   };
 

--- a/src/readers/DataInterface.cpp
+++ b/src/readers/DataInterface.cpp
@@ -49,20 +49,32 @@ std::default_random_engine * DataInterface::getGenerator() {
   return &generator;
 }
 
-void DataInterface::toggleCompliance(int interventionIndex, bool value) {
-  interventionStatuses[interventionIndex] &= ~INTERVENTION_WILL_COMPLY;
-  interventionStatuses[interventionIndex] |= INTERVENTION_WILL_COMPLY * value;
+int DataInterface::interventionIdToIndex(InterventionId id) const {
+  if (id >= interventionStatuses.size()) {
+    return id - interventionStatuses.size();
+  } else {
+    return id;
+  }
 }
 
-bool DataInterface::willComply(int interventionIndex) {
-  return interventionStatuses[interventionIndex] & INTERVENTION_WILL_COMPLY;
+void DataInterface::toggleCompliance(InterventionId id, bool value) {
+  int index = interventionIdToIndex(id);
+  interventionStatuses[index] &= ~INTERVENTION_WILL_COMPLY;
+  interventionStatuses[index] |= INTERVENTION_WILL_COMPLY * value;
 }
 
-void DataInterface::toggleActivity(int interventionIndex, bool value) {
-  interventionStatuses[interventionIndex] &= ~INTERVENTION_IS_ACTIVE;
-  interventionStatuses[interventionIndex] |= INTERVENTION_IS_ACTIVE * value;
+bool DataInterface::willComply(InterventionId id) const {
+  int index = interventionIdToIndex(id);
+  return interventionStatuses[index] & INTERVENTION_WILL_COMPLY;
 }
 
-bool DataInterface::isActive(int interventionIndex) {
-  return interventionStatuses[interventionIndex] & INTERVENTION_IS_ACTIVE;
+void DataInterface::toggleActivity(InterventionId id, bool value) {
+  int index = interventionIdToIndex(id);
+  interventionStatuses[index] &= ~INTERVENTION_IS_ACTIVE;
+  interventionStatuses[index] |= INTERVENTION_IS_ACTIVE * value;
+}
+
+bool DataInterface::isActive(InterventionId id) const {
+  int index = interventionIdToIndex(id);
+  return interventionStatuses[index] & INTERVENTION_IS_ACTIVE;
 }

--- a/src/readers/DataInterface.cpp
+++ b/src/readers/DataInterface.cpp
@@ -12,7 +12,7 @@
 
 DataInterface::DataInterface(const AttributeTable &attributes, int numInterventions) {
   if (0 != numInterventions) {
-    willComplyWithIntervention.resize(numInterventions);
+    interventionStatuses.resize(numInterventions);
   }
 
   // Treat all attributes same, no need to make distinction
@@ -50,9 +50,19 @@ std::default_random_engine * DataInterface::getGenerator() {
 }
 
 void DataInterface::toggleCompliance(int interventionIndex, bool value) {
-  willComplyWithIntervention[interventionIndex] = value;
+  interventionStatuses[interventionIndex] &= ~INTERVENTION_WILL_COMPLY;
+  interventionStatuses[interventionIndex] |= INTERVENTION_WILL_COMPLY * value;
 }
 
 bool DataInterface::willComply(int interventionIndex) {
-  return willComplyWithIntervention[interventionIndex];
+  return interventionStatuses[interventionIndex] & INTERVENTION_WILL_COMPLY;
+}
+
+void DataInterface::toggleActivity(int interventionIndex, bool value) {
+  interventionStatuses[interventionIndex] &= ~INTERVENTION_IS_ACTIVE;
+  interventionStatuses[interventionIndex] |= INTERVENTION_IS_ACTIVE * value;
+}
+
+bool DataInterface::isActive(int interventionIndex) {
+  return interventionStatuses[interventionIndex] & INTERVENTION_IS_ACTIVE;
 }

--- a/src/readers/DataInterface.h
+++ b/src/readers/DataInterface.h
@@ -48,6 +48,6 @@ class DataInterface {
   void toggleActivity(int interventionIndex, bool value);
   bool isActive(int interventionIndex);
   virtual void filterVisits(const void *cause, VisitTest keepVisit) = 0;
-  virtual void restoreVisits(const void *cause) = 0;
+  virtual void restoreVisits(const void *cause, VisitTest restoreVisit) = 0;
 };
 #endif  // READERS_DATAINTERFACE_H_

--- a/src/readers/DataInterface.h
+++ b/src/readers/DataInterface.h
@@ -29,8 +29,9 @@ class DataInterface {
   // Various dynamic attributes
   std::vector<union Data> data;
 
-  // Indicates whether or not this entity will comply with a given intervention
-  std::vector<bool> willComplyWithIntervention;
+  // Indicates whether or not this entity will comply with a given intervention,
+  // whether or not said intervention is active, etc
+  std::vector<InterventionStatus> interventionStatuses;
 
  public:
   DataInterface() = default;
@@ -44,6 +45,8 @@ class DataInterface {
   std::default_random_engine * getGenerator();
   void toggleCompliance(int interventionIndex, bool value);
   bool willComply(int interventionIndex);
+  void toggleActivity(int interventionIndex, bool value);
+  bool isActive(int interventionIndex);
   virtual void filterVisits(const void *cause, VisitTest keepVisit) = 0;
   virtual void restoreVisits(const void *cause) = 0;
 };

--- a/src/readers/DataInterface.h
+++ b/src/readers/DataInterface.h
@@ -43,11 +43,12 @@ class DataInterface {
   std::vector<union Data> &getData();
   void setSeed(int seed);
   std::default_random_engine * getGenerator();
-  void toggleCompliance(int interventionIndex, bool value);
-  bool willComply(int interventionIndex);
-  void toggleActivity(int interventionIndex, bool value);
-  bool isActive(int interventionIndex);
-  virtual void filterVisits(const void *cause, VisitTest keepVisit) = 0;
-  virtual void restoreVisits(const void *cause, VisitTest restoreVisit) = 0;
+  void toggleCompliance(InterventionId interventionIndex, bool value);
+  inline int interventionIdToIndex(InterventionId id) const;
+  bool willComply(InterventionId id) const;
+  void toggleActivity(InterventionId id, bool value);
+  bool isActive(InterventionId id) const;
+  virtual void filterVisits(InterventionId interventionId, VisitTest keepVisit) = 0;
+  virtual void restoreVisits(InterventionId interventionId, VisitTest restoreVisit) = 0;
 };
 #endif  // READERS_DATAINTERFACE_H_


### PR DESCRIPTION
- Moved implementation of how to apply all of a chare's people/locations to the `Intervention<T>` classes
- Added separate implementation to `VisitFilterIntervention<Person>` (`VisitFilterIntervention<Location>` uses the superclass method) which collects a set of people with the intervention applied to and removed from them and sends it to the appropriate location chares to filter visits there